### PR TITLE
Fix surplus days on leap years 

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,8 +79,8 @@ python3 ceda_ftp_download.py --input /badc/ukmo-hadobs/data/insitu/MOHC/HadOBS/H
 
 Datasets used in this project (raw, processed and debiased) have been pre-downloaded/pre-processed and stored in an Azure fileshare set-up for the clim-recal project (https://dymestorage1.file.core.windows.net/vmfileshare). You need to be given access, and register your IP address to the approved list in the following way from the azure portal:
 
-- Go to dymestorage1 page
-- Security + networking tab
+- Go to dymestorage1 page `Home > Storage accounts > dymestorage1`
+- Navigate to *Networking* tab under Security + networking
 - Add your IP under the Firewall section
 
 Once you have access you can mount the fileshare. On a Mac you can do it from a terminal:

--- a/check_calendar_log.txt
+++ b/check_calendar_log.txt
@@ -1,0 +1,1943 @@
+******************** Comparing raw data:  /Volumes/vmfileshare/ClimateData/Raw/HadsUKgrid/tasmax/day ********************
+******************** to resampled data: /Volumes/vmfileshare/ClimateData/Processed/HadsUKgrid/resampled_2.2km/tasmax/day ********************
+File: tasmax_hadukgrid_uk_1km_day_19800101-19800131.nc produced errors:
+raw # days: 31 - resampled # days: 30
+Dates in raw not in resampled: {'1980-01-31'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_19800301-19800331.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1980-03-31'}
+Dates in resampled not in raw: {'1980-02-30'}
+File: tasmax_hadukgrid_uk_1km_day_19800401-19800430.nc produced errors:
+raw # days: 30 - resampled # days: 30
+Dates in raw not in resampled: {'1980-04-30'}
+Dates in resampled not in raw: {'1980-03-30'}
+File: tasmax_hadukgrid_uk_1km_day_19800501-19800531.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1980-05-31'}
+Dates in resampled not in raw: {'1980-04-30'}
+File: tasmax_hadukgrid_uk_1km_day_19800601-19800630.nc produced errors:
+raw # days: 30 - resampled # days: 30
+Dates in raw not in resampled: {'1980-06-30'}
+Dates in resampled not in raw: {'1980-05-30'}
+File: tasmax_hadukgrid_uk_1km_day_19800701-19800731.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1980-07-31'}
+Dates in resampled not in raw: {'1980-06-30'}
+File: tasmax_hadukgrid_uk_1km_day_19800801-19800831.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1980-08-31'}
+Dates in resampled not in raw: {'1980-07-30'}
+File: tasmax_hadukgrid_uk_1km_day_19801001-19801031.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1980-10-31'}
+Dates in resampled not in raw: {'1980-09-30'}
+File: tasmax_hadukgrid_uk_1km_day_19801201-19801231.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1980-12-31'}
+Dates in resampled not in raw: {'1980-11-30'}
+File: tasmax_hadukgrid_uk_1km_day_19810101-19810131.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1981-01-31'}
+Dates in resampled not in raw: {'1981-02-01'}
+File: tasmax_hadukgrid_uk_1km_day_19810201-19810228.nc produced errors:
+raw # days: 28 - resampled # days: 27
+Dates in raw not in resampled: {'1981-02-01'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_19810301-19810331.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1981-03-31', '1981-03-30'}
+Dates in resampled not in raw: {'1981-02-29', '1981-02-30'}
+File: tasmax_hadukgrid_uk_1km_day_19810401-19810430.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'1981-04-30', '1981-04-29'}
+Dates in resampled not in raw: {'1981-03-30'}
+File: tasmax_hadukgrid_uk_1km_day_19810501-19810531.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1981-05-31', '1981-05-30'}
+Dates in resampled not in raw: {'1981-04-30', '1981-04-29'}
+File: tasmax_hadukgrid_uk_1km_day_19810601-19810630.nc produced errors:
+raw # days: 30 - resampled # days: 30
+Dates in raw not in resampled: {'1981-06-30'}
+Dates in resampled not in raw: {'1981-05-30'}
+File: tasmax_hadukgrid_uk_1km_day_19810701-19810731.nc produced errors:
+raw # days: 31 - resampled # days: 30
+Dates in raw not in resampled: {'1981-07-31', '1981-07-30'}
+Dates in resampled not in raw: {'1981-06-30'}
+File: tasmax_hadukgrid_uk_1km_day_19810801-19810831.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1981-08-31'}
+Dates in resampled not in raw: {'1981-07-30'}
+File: tasmax_hadukgrid_uk_1km_day_19810901-19810930.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'1981-09-30'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_19811001-19811031.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1981-10-31'}
+Dates in resampled not in raw: {'1981-09-30'}
+File: tasmax_hadukgrid_uk_1km_day_19811101-19811130.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'1981-11-30'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_19811201-19811231.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1981-12-31'}
+Dates in resampled not in raw: {'1981-11-30'}
+File: tasmax_hadukgrid_uk_1km_day_19820101-19820131.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1982-01-31'}
+Dates in resampled not in raw: {'1982-02-01'}
+File: tasmax_hadukgrid_uk_1km_day_19820201-19820228.nc produced errors:
+raw # days: 28 - resampled # days: 27
+Dates in raw not in resampled: {'1982-02-01'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_19820301-19820331.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1982-03-31', '1982-03-30'}
+Dates in resampled not in raw: {'1982-02-29', '1982-02-30'}
+File: tasmax_hadukgrid_uk_1km_day_19820401-19820430.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'1982-04-29', '1982-04-30'}
+Dates in resampled not in raw: {'1982-03-30'}
+File: tasmax_hadukgrid_uk_1km_day_19820501-19820531.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1982-05-31', '1982-05-30'}
+Dates in resampled not in raw: {'1982-04-29', '1982-04-30'}
+File: tasmax_hadukgrid_uk_1km_day_19820601-19820630.nc produced errors:
+raw # days: 30 - resampled # days: 30
+Dates in raw not in resampled: {'1982-06-30'}
+Dates in resampled not in raw: {'1982-05-30'}
+File: tasmax_hadukgrid_uk_1km_day_19820701-19820731.nc produced errors:
+raw # days: 31 - resampled # days: 30
+Dates in raw not in resampled: {'1982-07-30', '1982-07-31'}
+Dates in resampled not in raw: {'1982-06-30'}
+File: tasmax_hadukgrid_uk_1km_day_19820801-19820831.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1982-08-31'}
+Dates in resampled not in raw: {'1982-07-30'}
+File: tasmax_hadukgrid_uk_1km_day_19820901-19820930.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'1982-09-30'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_19821001-19821031.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1982-10-31'}
+Dates in resampled not in raw: {'1982-09-30'}
+File: tasmax_hadukgrid_uk_1km_day_19821101-19821130.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'1982-11-30'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_19821201-19821231.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1982-12-31'}
+Dates in resampled not in raw: {'1982-11-30'}
+File: tasmax_hadukgrid_uk_1km_day_19830101-19830131.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1983-01-31'}
+Dates in resampled not in raw: {'1983-02-01'}
+File: tasmax_hadukgrid_uk_1km_day_19830201-19830228.nc produced errors:
+raw # days: 28 - resampled # days: 27
+Dates in raw not in resampled: {'1983-02-01'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_19830301-19830331.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1983-03-30', '1983-03-31'}
+Dates in resampled not in raw: {'1983-02-30', '1983-02-29'}
+File: tasmax_hadukgrid_uk_1km_day_19830401-19830430.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'1983-04-29', '1983-04-30'}
+Dates in resampled not in raw: {'1983-03-30'}
+File: tasmax_hadukgrid_uk_1km_day_19830501-19830531.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1983-05-31', '1983-05-30'}
+Dates in resampled not in raw: {'1983-04-29', '1983-04-30'}
+File: tasmax_hadukgrid_uk_1km_day_19830601-19830630.nc produced errors:
+raw # days: 30 - resampled # days: 30
+Dates in raw not in resampled: {'1983-06-30'}
+Dates in resampled not in raw: {'1983-05-30'}
+File: tasmax_hadukgrid_uk_1km_day_19830701-19830731.nc produced errors:
+raw # days: 31 - resampled # days: 30
+Dates in raw not in resampled: {'1983-07-31', '1983-07-30'}
+Dates in resampled not in raw: {'1983-06-30'}
+File: tasmax_hadukgrid_uk_1km_day_19830801-19830831.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1983-08-31'}
+Dates in resampled not in raw: {'1983-07-30'}
+File: tasmax_hadukgrid_uk_1km_day_19830901-19830930.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'1983-09-30'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_19831001-19831031.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1983-10-31'}
+Dates in resampled not in raw: {'1983-09-30'}
+File: tasmax_hadukgrid_uk_1km_day_19831101-19831130.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'1983-11-30'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_19831201-19831231.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1983-12-31'}
+Dates in resampled not in raw: {'1983-11-30'}
+File: tasmax_hadukgrid_uk_1km_day_19840101-19840131.nc produced errors:
+raw # days: 31 - resampled # days: 30
+Dates in raw not in resampled: {'1984-01-31'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_19840301-19840331.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1984-03-31'}
+Dates in resampled not in raw: {'1984-02-30'}
+File: tasmax_hadukgrid_uk_1km_day_19840401-19840430.nc produced errors:
+raw # days: 30 - resampled # days: 30
+Dates in raw not in resampled: {'1984-04-30'}
+Dates in resampled not in raw: {'1984-03-30'}
+File: tasmax_hadukgrid_uk_1km_day_19840501-19840531.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1984-05-31'}
+Dates in resampled not in raw: {'1984-04-30'}
+File: tasmax_hadukgrid_uk_1km_day_19840601-19840630.nc produced errors:
+raw # days: 30 - resampled # days: 30
+Dates in raw not in resampled: {'1984-06-30'}
+Dates in resampled not in raw: {'1984-05-30'}
+File: tasmax_hadukgrid_uk_1km_day_19840701-19840731.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1984-07-31'}
+Dates in resampled not in raw: {'1984-06-30'}
+File: tasmax_hadukgrid_uk_1km_day_19840801-19840831.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1984-08-31'}
+Dates in resampled not in raw: {'1984-07-30'}
+File: tasmax_hadukgrid_uk_1km_day_19841001-19841031.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1984-10-31'}
+Dates in resampled not in raw: {'1984-09-30'}
+File: tasmax_hadukgrid_uk_1km_day_19841201-19841231.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1984-12-31'}
+Dates in resampled not in raw: {'1984-11-30'}
+File: tasmax_hadukgrid_uk_1km_day_19850101-19850131.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1985-01-31'}
+Dates in resampled not in raw: {'1985-02-01'}
+File: tasmax_hadukgrid_uk_1km_day_19850201-19850228.nc produced errors:
+raw # days: 28 - resampled # days: 27
+Dates in raw not in resampled: {'1985-02-01'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_19850301-19850331.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1985-03-31', '1985-03-30'}
+Dates in resampled not in raw: {'1985-02-29', '1985-02-30'}
+File: tasmax_hadukgrid_uk_1km_day_19850401-19850430.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'1985-04-30', '1985-04-29'}
+Dates in resampled not in raw: {'1985-03-30'}
+File: tasmax_hadukgrid_uk_1km_day_19850501-19850531.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1985-05-31', '1985-05-30'}
+Dates in resampled not in raw: {'1985-04-30', '1985-04-29'}
+File: tasmax_hadukgrid_uk_1km_day_19850601-19850630.nc produced errors:
+raw # days: 30 - resampled # days: 30
+Dates in raw not in resampled: {'1985-06-30'}
+Dates in resampled not in raw: {'1985-05-30'}
+File: tasmax_hadukgrid_uk_1km_day_19850701-19850731.nc produced errors:
+raw # days: 31 - resampled # days: 30
+Dates in raw not in resampled: {'1985-07-31', '1985-07-30'}
+Dates in resampled not in raw: {'1985-06-30'}
+File: tasmax_hadukgrid_uk_1km_day_19850801-19850831.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1985-08-31'}
+Dates in resampled not in raw: {'1985-07-30'}
+File: tasmax_hadukgrid_uk_1km_day_19850901-19850930.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'1985-09-30'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_19851001-19851031.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1985-10-31'}
+Dates in resampled not in raw: {'1985-09-30'}
+File: tasmax_hadukgrid_uk_1km_day_19851101-19851130.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'1985-11-30'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_19851201-19851231.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1985-12-31'}
+Dates in resampled not in raw: {'1985-11-30'}
+File: tasmax_hadukgrid_uk_1km_day_19860101-19860131.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1986-01-31'}
+Dates in resampled not in raw: {'1986-02-01'}
+File: tasmax_hadukgrid_uk_1km_day_19860201-19860228.nc produced errors:
+raw # days: 28 - resampled # days: 27
+Dates in raw not in resampled: {'1986-02-01'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_19860301-19860331.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1986-03-31', '1986-03-30'}
+Dates in resampled not in raw: {'1986-02-30', '1986-02-29'}
+File: tasmax_hadukgrid_uk_1km_day_19860401-19860430.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'1986-04-30', '1986-04-29'}
+Dates in resampled not in raw: {'1986-03-30'}
+File: tasmax_hadukgrid_uk_1km_day_19860501-19860531.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1986-05-30', '1986-05-31'}
+Dates in resampled not in raw: {'1986-04-30', '1986-04-29'}
+File: tasmax_hadukgrid_uk_1km_day_19860601-19860630.nc produced errors:
+raw # days: 30 - resampled # days: 30
+Dates in raw not in resampled: {'1986-06-30'}
+Dates in resampled not in raw: {'1986-05-30'}
+File: tasmax_hadukgrid_uk_1km_day_19860701-19860731.nc produced errors:
+raw # days: 31 - resampled # days: 30
+Dates in raw not in resampled: {'1986-07-30', '1986-07-31'}
+Dates in resampled not in raw: {'1986-06-30'}
+File: tasmax_hadukgrid_uk_1km_day_19860801-19860831.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1986-08-31'}
+Dates in resampled not in raw: {'1986-07-30'}
+File: tasmax_hadukgrid_uk_1km_day_19860901-19860930.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'1986-09-30'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_19861001-19861031.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1986-10-31'}
+Dates in resampled not in raw: {'1986-09-30'}
+File: tasmax_hadukgrid_uk_1km_day_19861101-19861130.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'1986-11-30'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_19861201-19861231.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1986-12-31'}
+Dates in resampled not in raw: {'1986-11-30'}
+File: tasmax_hadukgrid_uk_1km_day_19870101-19870131.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1987-01-31'}
+Dates in resampled not in raw: {'1987-02-01'}
+File: tasmax_hadukgrid_uk_1km_day_19870201-19870228.nc produced errors:
+raw # days: 28 - resampled # days: 27
+Dates in raw not in resampled: {'1987-02-01'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_19870301-19870331.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1987-03-30', '1987-03-31'}
+Dates in resampled not in raw: {'1987-02-30', '1987-02-29'}
+File: tasmax_hadukgrid_uk_1km_day_19870401-19870430.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'1987-04-29', '1987-04-30'}
+Dates in resampled not in raw: {'1987-03-30'}
+File: tasmax_hadukgrid_uk_1km_day_19870501-19870531.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1987-05-31', '1987-05-30'}
+Dates in resampled not in raw: {'1987-04-29', '1987-04-30'}
+File: tasmax_hadukgrid_uk_1km_day_19870601-19870630.nc produced errors:
+raw # days: 30 - resampled # days: 30
+Dates in raw not in resampled: {'1987-06-30'}
+Dates in resampled not in raw: {'1987-05-30'}
+File: tasmax_hadukgrid_uk_1km_day_19870701-19870731.nc produced errors:
+raw # days: 31 - resampled # days: 30
+Dates in raw not in resampled: {'1987-07-31', '1987-07-30'}
+Dates in resampled not in raw: {'1987-06-30'}
+File: tasmax_hadukgrid_uk_1km_day_19870801-19870831.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1987-08-31'}
+Dates in resampled not in raw: {'1987-07-30'}
+File: tasmax_hadukgrid_uk_1km_day_19870901-19870930.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'1987-09-30'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_19871001-19871031.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1987-10-31'}
+Dates in resampled not in raw: {'1987-09-30'}
+File: tasmax_hadukgrid_uk_1km_day_19871101-19871130.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'1987-11-30'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_19871201-19871231.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1987-12-31'}
+Dates in resampled not in raw: {'1987-11-30'}
+File: tasmax_hadukgrid_uk_1km_day_19880101-19880131.nc produced errors:
+raw # days: 31 - resampled # days: 30
+Dates in raw not in resampled: {'1988-01-31'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_19880301-19880331.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1988-03-31'}
+Dates in resampled not in raw: {'1988-02-30'}
+File: tasmax_hadukgrid_uk_1km_day_19880401-19880430.nc produced errors:
+raw # days: 30 - resampled # days: 30
+Dates in raw not in resampled: {'1988-04-30'}
+Dates in resampled not in raw: {'1988-03-30'}
+File: tasmax_hadukgrid_uk_1km_day_19880501-19880531.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1988-05-31'}
+Dates in resampled not in raw: {'1988-04-30'}
+File: tasmax_hadukgrid_uk_1km_day_19880601-19880630.nc produced errors:
+raw # days: 30 - resampled # days: 30
+Dates in raw not in resampled: {'1988-06-30'}
+Dates in resampled not in raw: {'1988-05-30'}
+File: tasmax_hadukgrid_uk_1km_day_19880701-19880731.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1988-07-31'}
+Dates in resampled not in raw: {'1988-06-30'}
+File: tasmax_hadukgrid_uk_1km_day_19880801-19880831.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1988-08-31'}
+Dates in resampled not in raw: {'1988-07-30'}
+File: tasmax_hadukgrid_uk_1km_day_19881001-19881031.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1988-10-31'}
+Dates in resampled not in raw: {'1988-09-30'}
+File: tasmax_hadukgrid_uk_1km_day_19881201-19881231.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1988-12-31'}
+Dates in resampled not in raw: {'1988-11-30'}
+File: tasmax_hadukgrid_uk_1km_day_19890101-19890131.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1989-01-31'}
+Dates in resampled not in raw: {'1989-02-01'}
+File: tasmax_hadukgrid_uk_1km_day_19890201-19890228.nc produced errors:
+raw # days: 28 - resampled # days: 27
+Dates in raw not in resampled: {'1989-02-01'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_19890301-19890331.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1989-03-31', '1989-03-30'}
+Dates in resampled not in raw: {'1989-02-29', '1989-02-30'}
+File: tasmax_hadukgrid_uk_1km_day_19890401-19890430.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'1989-04-29', '1989-04-30'}
+Dates in resampled not in raw: {'1989-03-30'}
+File: tasmax_hadukgrid_uk_1km_day_19890501-19890531.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1989-05-31', '1989-05-30'}
+Dates in resampled not in raw: {'1989-04-29', '1989-04-30'}
+File: tasmax_hadukgrid_uk_1km_day_19890601-19890630.nc produced errors:
+raw # days: 30 - resampled # days: 30
+Dates in raw not in resampled: {'1989-06-30'}
+Dates in resampled not in raw: {'1989-05-30'}
+File: tasmax_hadukgrid_uk_1km_day_19890701-19890731.nc produced errors:
+raw # days: 31 - resampled # days: 30
+Dates in raw not in resampled: {'1989-07-30', '1989-07-31'}
+Dates in resampled not in raw: {'1989-06-30'}
+File: tasmax_hadukgrid_uk_1km_day_19890801-19890831.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1989-08-31'}
+Dates in resampled not in raw: {'1989-07-30'}
+File: tasmax_hadukgrid_uk_1km_day_19890901-19890930.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'1989-09-30'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_19891001-19891031.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1989-10-31'}
+Dates in resampled not in raw: {'1989-09-30'}
+File: tasmax_hadukgrid_uk_1km_day_19891101-19891130.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'1989-11-30'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_19891201-19891231.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1989-12-31'}
+Dates in resampled not in raw: {'1989-11-30'}
+File: tasmax_hadukgrid_uk_1km_day_19900101-19900131.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1990-01-31'}
+Dates in resampled not in raw: {'1990-02-01'}
+File: tasmax_hadukgrid_uk_1km_day_19900201-19900228.nc produced errors:
+raw # days: 28 - resampled # days: 27
+Dates in raw not in resampled: {'1990-02-01'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_19900301-19900331.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1990-03-30', '1990-03-31'}
+Dates in resampled not in raw: {'1990-02-29', '1990-02-30'}
+File: tasmax_hadukgrid_uk_1km_day_19900401-19900430.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'1990-04-30', '1990-04-29'}
+Dates in resampled not in raw: {'1990-03-30'}
+File: tasmax_hadukgrid_uk_1km_day_19900501-19900531.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1990-05-30', '1990-05-31'}
+Dates in resampled not in raw: {'1990-04-30', '1990-04-29'}
+File: tasmax_hadukgrid_uk_1km_day_19900601-19900630.nc produced errors:
+raw # days: 30 - resampled # days: 30
+Dates in raw not in resampled: {'1990-06-30'}
+Dates in resampled not in raw: {'1990-05-30'}
+File: tasmax_hadukgrid_uk_1km_day_19900701-19900731.nc produced errors:
+raw # days: 31 - resampled # days: 30
+Dates in raw not in resampled: {'1990-07-31', '1990-07-30'}
+Dates in resampled not in raw: {'1990-06-30'}
+File: tasmax_hadukgrid_uk_1km_day_19900801-19900831.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1990-08-31'}
+Dates in resampled not in raw: {'1990-07-30'}
+File: tasmax_hadukgrid_uk_1km_day_19900901-19900930.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'1990-09-30'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_19901001-19901031.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1990-10-31'}
+Dates in resampled not in raw: {'1990-09-30'}
+File: tasmax_hadukgrid_uk_1km_day_19901101-19901130.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'1990-11-30'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_19901201-19901231.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1990-12-31'}
+Dates in resampled not in raw: {'1990-11-30'}
+File: tasmax_hadukgrid_uk_1km_day_19910101-19910131.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1991-01-31'}
+Dates in resampled not in raw: {'1991-02-01'}
+File: tasmax_hadukgrid_uk_1km_day_19910201-19910228.nc produced errors:
+raw # days: 28 - resampled # days: 27
+Dates in raw not in resampled: {'1991-02-01'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_19910301-19910331.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1991-03-30', '1991-03-31'}
+Dates in resampled not in raw: {'1991-02-30', '1991-02-29'}
+File: tasmax_hadukgrid_uk_1km_day_19910401-19910430.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'1991-04-30', '1991-04-29'}
+Dates in resampled not in raw: {'1991-03-30'}
+File: tasmax_hadukgrid_uk_1km_day_19910501-19910531.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1991-05-30', '1991-05-31'}
+Dates in resampled not in raw: {'1991-04-29', '1991-04-30'}
+File: tasmax_hadukgrid_uk_1km_day_19910601-19910630.nc produced errors:
+raw # days: 30 - resampled # days: 30
+Dates in raw not in resampled: {'1991-06-30'}
+Dates in resampled not in raw: {'1991-05-30'}
+File: tasmax_hadukgrid_uk_1km_day_19910701-19910731.nc produced errors:
+raw # days: 31 - resampled # days: 30
+Dates in raw not in resampled: {'1991-07-31', '1991-07-30'}
+Dates in resampled not in raw: {'1991-06-30'}
+File: tasmax_hadukgrid_uk_1km_day_19910801-19910831.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1991-08-31'}
+Dates in resampled not in raw: {'1991-07-30'}
+File: tasmax_hadukgrid_uk_1km_day_19910901-19910930.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'1991-09-30'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_19911001-19911031.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1991-10-31'}
+Dates in resampled not in raw: {'1991-09-30'}
+File: tasmax_hadukgrid_uk_1km_day_19911101-19911130.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'1991-11-30'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_19911201-19911231.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1991-12-31'}
+Dates in resampled not in raw: {'1991-11-30'}
+File: tasmax_hadukgrid_uk_1km_day_19920101-19920131.nc produced errors:
+raw # days: 31 - resampled # days: 30
+Dates in raw not in resampled: {'1992-01-31'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_19920301-19920331.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1992-03-31'}
+Dates in resampled not in raw: {'1992-02-30'}
+File: tasmax_hadukgrid_uk_1km_day_19920401-19920430.nc produced errors:
+raw # days: 30 - resampled # days: 30
+Dates in raw not in resampled: {'1992-04-30'}
+Dates in resampled not in raw: {'1992-03-30'}
+File: tasmax_hadukgrid_uk_1km_day_19920501-19920531.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1992-05-31'}
+Dates in resampled not in raw: {'1992-04-30'}
+File: tasmax_hadukgrid_uk_1km_day_19920601-19920630.nc produced errors:
+raw # days: 30 - resampled # days: 30
+Dates in raw not in resampled: {'1992-06-30'}
+Dates in resampled not in raw: {'1992-05-30'}
+File: tasmax_hadukgrid_uk_1km_day_19920701-19920731.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1992-07-31'}
+Dates in resampled not in raw: {'1992-06-30'}
+File: tasmax_hadukgrid_uk_1km_day_19920801-19920831.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1992-08-31'}
+Dates in resampled not in raw: {'1992-07-30'}
+File: tasmax_hadukgrid_uk_1km_day_19921001-19921031.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1992-10-31'}
+Dates in resampled not in raw: {'1992-09-30'}
+File: tasmax_hadukgrid_uk_1km_day_19921201-19921231.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1992-12-31'}
+Dates in resampled not in raw: {'1992-11-30'}
+File: tasmax_hadukgrid_uk_1km_day_19930101-19930131.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1993-01-31'}
+Dates in resampled not in raw: {'1993-02-01'}
+File: tasmax_hadukgrid_uk_1km_day_19930201-19930228.nc produced errors:
+raw # days: 28 - resampled # days: 27
+Dates in raw not in resampled: {'1993-02-01'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_19930301-19930331.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1993-03-30', '1993-03-31'}
+Dates in resampled not in raw: {'1993-02-30', '1993-02-29'}
+File: tasmax_hadukgrid_uk_1km_day_19930401-19930430.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'1993-04-29', '1993-04-30'}
+Dates in resampled not in raw: {'1993-03-30'}
+File: tasmax_hadukgrid_uk_1km_day_19930501-19930531.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1993-05-30', '1993-05-31'}
+Dates in resampled not in raw: {'1993-04-29', '1993-04-30'}
+File: tasmax_hadukgrid_uk_1km_day_19930601-19930630.nc produced errors:
+raw # days: 30 - resampled # days: 30
+Dates in raw not in resampled: {'1993-06-30'}
+Dates in resampled not in raw: {'1993-05-30'}
+File: tasmax_hadukgrid_uk_1km_day_19930701-19930731.nc produced errors:
+raw # days: 31 - resampled # days: 30
+Dates in raw not in resampled: {'1993-07-30', '1993-07-31'}
+Dates in resampled not in raw: {'1993-06-30'}
+File: tasmax_hadukgrid_uk_1km_day_19930801-19930831.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1993-08-31'}
+Dates in resampled not in raw: {'1993-07-30'}
+File: tasmax_hadukgrid_uk_1km_day_19930901-19930930.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'1993-09-30'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_19931001-19931031.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1993-10-31'}
+Dates in resampled not in raw: {'1993-09-30'}
+File: tasmax_hadukgrid_uk_1km_day_19931101-19931130.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'1993-11-30'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_19931201-19931231.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1993-12-31'}
+Dates in resampled not in raw: {'1993-11-30'}
+File: tasmax_hadukgrid_uk_1km_day_19940101-19940131.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1994-01-31'}
+Dates in resampled not in raw: {'1994-02-01'}
+File: tasmax_hadukgrid_uk_1km_day_19940201-19940228.nc produced errors:
+raw # days: 28 - resampled # days: 27
+Dates in raw not in resampled: {'1994-02-01'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_19940301-19940331.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1994-03-31', '1994-03-30'}
+Dates in resampled not in raw: {'1994-02-30', '1994-02-29'}
+File: tasmax_hadukgrid_uk_1km_day_19940401-19940430.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'1994-04-29', '1994-04-30'}
+Dates in resampled not in raw: {'1994-03-30'}
+File: tasmax_hadukgrid_uk_1km_day_19940501-19940531.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1994-05-30', '1994-05-31'}
+Dates in resampled not in raw: {'1994-04-29', '1994-04-30'}
+File: tasmax_hadukgrid_uk_1km_day_19940601-19940630.nc produced errors:
+raw # days: 30 - resampled # days: 30
+Dates in raw not in resampled: {'1994-06-30'}
+Dates in resampled not in raw: {'1994-05-30'}
+File: tasmax_hadukgrid_uk_1km_day_19940701-19940731.nc produced errors:
+raw # days: 31 - resampled # days: 30
+Dates in raw not in resampled: {'1994-07-31', '1994-07-30'}
+Dates in resampled not in raw: {'1994-06-30'}
+File: tasmax_hadukgrid_uk_1km_day_19940801-19940831.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1994-08-31'}
+Dates in resampled not in raw: {'1994-07-30'}
+File: tasmax_hadukgrid_uk_1km_day_19940901-19940930.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'1994-09-30'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_19941001-19941031.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1994-10-31'}
+Dates in resampled not in raw: {'1994-09-30'}
+File: tasmax_hadukgrid_uk_1km_day_19941101-19941130.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'1994-11-30'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_19941201-19941231.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1994-12-31'}
+Dates in resampled not in raw: {'1994-11-30'}
+File: tasmax_hadukgrid_uk_1km_day_19950101-19950131.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1995-01-31'}
+Dates in resampled not in raw: {'1995-02-01'}
+File: tasmax_hadukgrid_uk_1km_day_19950201-19950228.nc produced errors:
+raw # days: 28 - resampled # days: 27
+Dates in raw not in resampled: {'1995-02-01'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_19950301-19950331.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1995-03-31', '1995-03-30'}
+Dates in resampled not in raw: {'1995-02-30', '1995-02-29'}
+File: tasmax_hadukgrid_uk_1km_day_19950401-19950430.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'1995-04-29', '1995-04-30'}
+Dates in resampled not in raw: {'1995-03-30'}
+File: tasmax_hadukgrid_uk_1km_day_19950501-19950531.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1995-05-31', '1995-05-30'}
+Dates in resampled not in raw: {'1995-04-29', '1995-04-30'}
+File: tasmax_hadukgrid_uk_1km_day_19950601-19950630.nc produced errors:
+raw # days: 30 - resampled # days: 30
+Dates in raw not in resampled: {'1995-06-30'}
+Dates in resampled not in raw: {'1995-05-30'}
+File: tasmax_hadukgrid_uk_1km_day_19950701-19950731.nc produced errors:
+raw # days: 31 - resampled # days: 30
+Dates in raw not in resampled: {'1995-07-31', '1995-07-30'}
+Dates in resampled not in raw: {'1995-06-30'}
+File: tasmax_hadukgrid_uk_1km_day_19950801-19950831.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1995-08-31'}
+Dates in resampled not in raw: {'1995-07-30'}
+File: tasmax_hadukgrid_uk_1km_day_19950901-19950930.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'1995-09-30'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_19951001-19951031.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1995-10-31'}
+Dates in resampled not in raw: {'1995-09-30'}
+File: tasmax_hadukgrid_uk_1km_day_19951101-19951130.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'1995-11-30'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_19951201-19951231.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1995-12-31'}
+Dates in resampled not in raw: {'1995-11-30'}
+File: tasmax_hadukgrid_uk_1km_day_19960101-19960131.nc produced errors:
+raw # days: 31 - resampled # days: 30
+Dates in raw not in resampled: {'1996-01-31'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_19960301-19960331.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1996-03-31'}
+Dates in resampled not in raw: {'1996-02-30'}
+File: tasmax_hadukgrid_uk_1km_day_19960401-19960430.nc produced errors:
+raw # days: 30 - resampled # days: 30
+Dates in raw not in resampled: {'1996-04-30'}
+Dates in resampled not in raw: {'1996-03-30'}
+File: tasmax_hadukgrid_uk_1km_day_19960501-19960531.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1996-05-31'}
+Dates in resampled not in raw: {'1996-04-30'}
+File: tasmax_hadukgrid_uk_1km_day_19960601-19960630.nc produced errors:
+raw # days: 30 - resampled # days: 30
+Dates in raw not in resampled: {'1996-06-30'}
+Dates in resampled not in raw: {'1996-05-30'}
+File: tasmax_hadukgrid_uk_1km_day_19960701-19960731.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1996-07-31'}
+Dates in resampled not in raw: {'1996-06-30'}
+File: tasmax_hadukgrid_uk_1km_day_19960801-19960831.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1996-08-31'}
+Dates in resampled not in raw: {'1996-07-30'}
+File: tasmax_hadukgrid_uk_1km_day_19961001-19961031.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1996-10-31'}
+Dates in resampled not in raw: {'1996-09-30'}
+File: tasmax_hadukgrid_uk_1km_day_19961201-19961231.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1996-12-31'}
+Dates in resampled not in raw: {'1996-11-30'}
+File: tasmax_hadukgrid_uk_1km_day_19970101-19970131.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1997-01-31'}
+Dates in resampled not in raw: {'1997-02-01'}
+File: tasmax_hadukgrid_uk_1km_day_19970201-19970228.nc produced errors:
+raw # days: 28 - resampled # days: 27
+Dates in raw not in resampled: {'1997-02-01'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_19970301-19970331.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1997-03-31', '1997-03-30'}
+Dates in resampled not in raw: {'1997-02-30', '1997-02-29'}
+File: tasmax_hadukgrid_uk_1km_day_19970401-19970430.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'1997-04-29', '1997-04-30'}
+Dates in resampled not in raw: {'1997-03-30'}
+File: tasmax_hadukgrid_uk_1km_day_19970501-19970531.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1997-05-30', '1997-05-31'}
+Dates in resampled not in raw: {'1997-04-29', '1997-04-30'}
+File: tasmax_hadukgrid_uk_1km_day_19970601-19970630.nc produced errors:
+raw # days: 30 - resampled # days: 30
+Dates in raw not in resampled: {'1997-06-30'}
+Dates in resampled not in raw: {'1997-05-30'}
+File: tasmax_hadukgrid_uk_1km_day_19970701-19970731.nc produced errors:
+raw # days: 31 - resampled # days: 30
+Dates in raw not in resampled: {'1997-07-31', '1997-07-30'}
+Dates in resampled not in raw: {'1997-06-30'}
+File: tasmax_hadukgrid_uk_1km_day_19970801-19970831.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1997-08-31'}
+Dates in resampled not in raw: {'1997-07-30'}
+File: tasmax_hadukgrid_uk_1km_day_19970901-19970930.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'1997-09-30'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_19971001-19971031.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1997-10-31'}
+Dates in resampled not in raw: {'1997-09-30'}
+File: tasmax_hadukgrid_uk_1km_day_19971101-19971130.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'1997-11-30'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_19971201-19971231.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1997-12-31'}
+Dates in resampled not in raw: {'1997-11-30'}
+File: tasmax_hadukgrid_uk_1km_day_19980101-19980131.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1998-01-31'}
+Dates in resampled not in raw: {'1998-02-01'}
+File: tasmax_hadukgrid_uk_1km_day_19980201-19980228.nc produced errors:
+raw # days: 28 - resampled # days: 27
+Dates in raw not in resampled: {'1998-02-01'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_19980301-19980331.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1998-03-31', '1998-03-30'}
+Dates in resampled not in raw: {'1998-02-30', '1998-02-29'}
+File: tasmax_hadukgrid_uk_1km_day_19980401-19980430.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'1998-04-29', '1998-04-30'}
+Dates in resampled not in raw: {'1998-03-30'}
+File: tasmax_hadukgrid_uk_1km_day_19980501-19980531.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1998-05-31', '1998-05-30'}
+Dates in resampled not in raw: {'1998-04-29', '1998-04-30'}
+File: tasmax_hadukgrid_uk_1km_day_19980601-19980630.nc produced errors:
+raw # days: 30 - resampled # days: 30
+Dates in raw not in resampled: {'1998-06-30'}
+Dates in resampled not in raw: {'1998-05-30'}
+File: tasmax_hadukgrid_uk_1km_day_19980701-19980731.nc produced errors:
+raw # days: 31 - resampled # days: 30
+Dates in raw not in resampled: {'1998-07-31', '1998-07-30'}
+Dates in resampled not in raw: {'1998-06-30'}
+File: tasmax_hadukgrid_uk_1km_day_19980801-19980831.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1998-08-31'}
+Dates in resampled not in raw: {'1998-07-30'}
+File: tasmax_hadukgrid_uk_1km_day_19980901-19980930.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'1998-09-30'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_19981001-19981031.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1998-10-31'}
+Dates in resampled not in raw: {'1998-09-30'}
+File: tasmax_hadukgrid_uk_1km_day_19981101-19981130.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'1998-11-30'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_19981201-19981231.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1998-12-31'}
+Dates in resampled not in raw: {'1998-11-30'}
+File: tasmax_hadukgrid_uk_1km_day_19990101-19990131.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1999-01-31'}
+Dates in resampled not in raw: {'1999-02-01'}
+File: tasmax_hadukgrid_uk_1km_day_19990201-19990228.nc produced errors:
+raw # days: 28 - resampled # days: 27
+Dates in raw not in resampled: {'1999-02-01'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_19990301-19990331.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1999-03-31', '1999-03-30'}
+Dates in resampled not in raw: {'1999-02-29', '1999-02-30'}
+File: tasmax_hadukgrid_uk_1km_day_19990401-19990430.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'1999-04-29', '1999-04-30'}
+Dates in resampled not in raw: {'1999-03-30'}
+File: tasmax_hadukgrid_uk_1km_day_19990501-19990531.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1999-05-31', '1999-05-30'}
+Dates in resampled not in raw: {'1999-04-29', '1999-04-30'}
+File: tasmax_hadukgrid_uk_1km_day_19990601-19990630.nc produced errors:
+raw # days: 30 - resampled # days: 30
+Dates in raw not in resampled: {'1999-06-30'}
+Dates in resampled not in raw: {'1999-05-30'}
+File: tasmax_hadukgrid_uk_1km_day_19990701-19990731.nc produced errors:
+raw # days: 31 - resampled # days: 30
+Dates in raw not in resampled: {'1999-07-30', '1999-07-31'}
+Dates in resampled not in raw: {'1999-06-30'}
+File: tasmax_hadukgrid_uk_1km_day_19990801-19990831.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1999-08-31'}
+Dates in resampled not in raw: {'1999-07-30'}
+File: tasmax_hadukgrid_uk_1km_day_19990901-19990930.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'1999-09-30'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_19991001-19991031.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1999-10-31'}
+Dates in resampled not in raw: {'1999-09-30'}
+File: tasmax_hadukgrid_uk_1km_day_19991101-19991130.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'1999-11-30'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_19991201-19991231.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1999-12-31'}
+Dates in resampled not in raw: {'1999-11-30'}
+File: tasmax_hadukgrid_uk_1km_day_20000101-20000131.nc produced errors:
+raw # days: 31 - resampled # days: 30
+Dates in raw not in resampled: {'2000-01-31'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_20000301-20000331.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2000-03-31'}
+Dates in resampled not in raw: {'2000-02-30'}
+File: tasmax_hadukgrid_uk_1km_day_20000401-20000430.nc produced errors:
+raw # days: 30 - resampled # days: 30
+Dates in raw not in resampled: {'2000-04-30'}
+Dates in resampled not in raw: {'2000-03-30'}
+File: tasmax_hadukgrid_uk_1km_day_20000501-20000531.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2000-05-31'}
+Dates in resampled not in raw: {'2000-04-30'}
+File: tasmax_hadukgrid_uk_1km_day_20000601-20000630.nc produced errors:
+raw # days: 30 - resampled # days: 30
+Dates in raw not in resampled: {'2000-06-30'}
+Dates in resampled not in raw: {'2000-05-30'}
+File: tasmax_hadukgrid_uk_1km_day_20000701-20000731.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2000-07-31'}
+Dates in resampled not in raw: {'2000-06-30'}
+File: tasmax_hadukgrid_uk_1km_day_20000801-20000831.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2000-08-31'}
+Dates in resampled not in raw: {'2000-07-30'}
+File: tasmax_hadukgrid_uk_1km_day_20001001-20001031.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2000-10-31'}
+Dates in resampled not in raw: {'2000-09-30'}
+File: tasmax_hadukgrid_uk_1km_day_20001201-20001231.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2000-12-31'}
+Dates in resampled not in raw: {'2000-11-30'}
+File: tasmax_hadukgrid_uk_1km_day_20010101-20010131.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2001-01-31'}
+Dates in resampled not in raw: {'2001-02-01'}
+File: tasmax_hadukgrid_uk_1km_day_20010201-20010228.nc produced errors:
+raw # days: 28 - resampled # days: 27
+Dates in raw not in resampled: {'2001-02-01'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_20010301-20010331.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2001-03-31', '2001-03-30'}
+Dates in resampled not in raw: {'2001-02-30', '2001-02-29'}
+File: tasmax_hadukgrid_uk_1km_day_20010401-20010430.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'2001-04-29', '2001-04-30'}
+Dates in resampled not in raw: {'2001-03-30'}
+File: tasmax_hadukgrid_uk_1km_day_20010501-20010531.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2001-05-30', '2001-05-31'}
+Dates in resampled not in raw: {'2001-04-29', '2001-04-30'}
+File: tasmax_hadukgrid_uk_1km_day_20010601-20010630.nc produced errors:
+raw # days: 30 - resampled # days: 30
+Dates in raw not in resampled: {'2001-06-30'}
+Dates in resampled not in raw: {'2001-05-30'}
+File: tasmax_hadukgrid_uk_1km_day_20010701-20010731.nc produced errors:
+raw # days: 31 - resampled # days: 30
+Dates in raw not in resampled: {'2001-07-30', '2001-07-31'}
+Dates in resampled not in raw: {'2001-06-30'}
+File: tasmax_hadukgrid_uk_1km_day_20010801-20010831.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2001-08-31'}
+Dates in resampled not in raw: {'2001-07-30'}
+File: tasmax_hadukgrid_uk_1km_day_20010901-20010930.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'2001-09-30'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_20011001-20011031.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2001-10-31'}
+Dates in resampled not in raw: {'2001-09-30'}
+File: tasmax_hadukgrid_uk_1km_day_20011101-20011130.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'2001-11-30'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_20011201-20011231.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2001-12-31'}
+Dates in resampled not in raw: {'2001-11-30'}
+File: tasmax_hadukgrid_uk_1km_day_20020101-20020131.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2002-01-31'}
+Dates in resampled not in raw: {'2002-02-01'}
+File: tasmax_hadukgrid_uk_1km_day_20020201-20020228.nc produced errors:
+raw # days: 28 - resampled # days: 27
+Dates in raw not in resampled: {'2002-02-01'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_20020301-20020331.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2002-03-30', '2002-03-31'}
+Dates in resampled not in raw: {'2002-02-29', '2002-02-30'}
+File: tasmax_hadukgrid_uk_1km_day_20020401-20020430.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'2002-04-30', '2002-04-29'}
+Dates in resampled not in raw: {'2002-03-30'}
+File: tasmax_hadukgrid_uk_1km_day_20020501-20020531.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2002-05-31', '2002-05-30'}
+Dates in resampled not in raw: {'2002-04-30', '2002-04-29'}
+File: tasmax_hadukgrid_uk_1km_day_20020601-20020630.nc produced errors:
+raw # days: 30 - resampled # days: 30
+Dates in raw not in resampled: {'2002-06-30'}
+Dates in resampled not in raw: {'2002-05-30'}
+File: tasmax_hadukgrid_uk_1km_day_20020701-20020731.nc produced errors:
+raw # days: 31 - resampled # days: 30
+Dates in raw not in resampled: {'2002-07-30', '2002-07-31'}
+Dates in resampled not in raw: {'2002-06-30'}
+File: tasmax_hadukgrid_uk_1km_day_20020801-20020831.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2002-08-31'}
+Dates in resampled not in raw: {'2002-07-30'}
+File: tasmax_hadukgrid_uk_1km_day_20020901-20020930.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'2002-09-30'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_20021001-20021031.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2002-10-31'}
+Dates in resampled not in raw: {'2002-09-30'}
+File: tasmax_hadukgrid_uk_1km_day_20021101-20021130.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'2002-11-30'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_20021201-20021231.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2002-12-31'}
+Dates in resampled not in raw: {'2002-11-30'}
+File: tasmax_hadukgrid_uk_1km_day_20030101-20030131.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2003-01-31'}
+Dates in resampled not in raw: {'2003-02-01'}
+File: tasmax_hadukgrid_uk_1km_day_20030201-20030228.nc produced errors:
+raw # days: 28 - resampled # days: 27
+Dates in raw not in resampled: {'2003-02-01'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_20030301-20030331.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2003-03-30', '2003-03-31'}
+Dates in resampled not in raw: {'2003-02-29', '2003-02-30'}
+File: tasmax_hadukgrid_uk_1km_day_20030401-20030430.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'2003-04-30', '2003-04-29'}
+Dates in resampled not in raw: {'2003-03-30'}
+File: tasmax_hadukgrid_uk_1km_day_20030501-20030531.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2003-05-31', '2003-05-30'}
+Dates in resampled not in raw: {'2003-04-30', '2003-04-29'}
+File: tasmax_hadukgrid_uk_1km_day_20030601-20030630.nc produced errors:
+raw # days: 30 - resampled # days: 30
+Dates in raw not in resampled: {'2003-06-30'}
+Dates in resampled not in raw: {'2003-05-30'}
+File: tasmax_hadukgrid_uk_1km_day_20030701-20030731.nc produced errors:
+raw # days: 31 - resampled # days: 30
+Dates in raw not in resampled: {'2003-07-30', '2003-07-31'}
+Dates in resampled not in raw: {'2003-06-30'}
+File: tasmax_hadukgrid_uk_1km_day_20030801-20030831.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2003-08-31'}
+Dates in resampled not in raw: {'2003-07-30'}
+File: tasmax_hadukgrid_uk_1km_day_20030901-20030930.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'2003-09-30'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_20031001-20031031.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2003-10-31'}
+Dates in resampled not in raw: {'2003-09-30'}
+File: tasmax_hadukgrid_uk_1km_day_20031101-20031130.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'2003-11-30'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_20031201-20031231.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2003-12-31'}
+Dates in resampled not in raw: {'2003-11-30'}
+File: tasmax_hadukgrid_uk_1km_day_20040101-20040131.nc produced errors:
+raw # days: 31 - resampled # days: 30
+Dates in raw not in resampled: {'2004-01-31'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_20040301-20040331.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2004-03-31'}
+Dates in resampled not in raw: {'2004-02-30'}
+File: tasmax_hadukgrid_uk_1km_day_20040401-20040430.nc produced errors:
+raw # days: 30 - resampled # days: 30
+Dates in raw not in resampled: {'2004-04-30'}
+Dates in resampled not in raw: {'2004-03-30'}
+File: tasmax_hadukgrid_uk_1km_day_20040501-20040531.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2004-05-31'}
+Dates in resampled not in raw: {'2004-04-30'}
+File: tasmax_hadukgrid_uk_1km_day_20040601-20040630.nc produced errors:
+raw # days: 30 - resampled # days: 30
+Dates in raw not in resampled: {'2004-06-30'}
+Dates in resampled not in raw: {'2004-05-30'}
+File: tasmax_hadukgrid_uk_1km_day_20040701-20040731.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2004-07-31'}
+Dates in resampled not in raw: {'2004-06-30'}
+File: tasmax_hadukgrid_uk_1km_day_20040801-20040831.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2004-08-31'}
+Dates in resampled not in raw: {'2004-07-30'}
+File: tasmax_hadukgrid_uk_1km_day_20041001-20041031.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2004-10-31'}
+Dates in resampled not in raw: {'2004-09-30'}
+File: tasmax_hadukgrid_uk_1km_day_20041201-20041231.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2004-12-31'}
+Dates in resampled not in raw: {'2004-11-30'}
+File: tasmax_hadukgrid_uk_1km_day_20050101-20050131.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2005-01-31'}
+Dates in resampled not in raw: {'2005-02-01'}
+File: tasmax_hadukgrid_uk_1km_day_20050201-20050228.nc produced errors:
+raw # days: 28 - resampled # days: 27
+Dates in raw not in resampled: {'2005-02-01'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_20050301-20050331.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2005-03-31', '2005-03-30'}
+Dates in resampled not in raw: {'2005-02-29', '2005-02-30'}
+File: tasmax_hadukgrid_uk_1km_day_20050401-20050430.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'2005-04-30', '2005-04-29'}
+Dates in resampled not in raw: {'2005-03-30'}
+File: tasmax_hadukgrid_uk_1km_day_20050501-20050531.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2005-05-31', '2005-05-30'}
+Dates in resampled not in raw: {'2005-04-30', '2005-04-29'}
+File: tasmax_hadukgrid_uk_1km_day_20050601-20050630.nc produced errors:
+raw # days: 30 - resampled # days: 30
+Dates in raw not in resampled: {'2005-06-30'}
+Dates in resampled not in raw: {'2005-05-30'}
+File: tasmax_hadukgrid_uk_1km_day_20050701-20050731.nc produced errors:
+raw # days: 31 - resampled # days: 30
+Dates in raw not in resampled: {'2005-07-31', '2005-07-30'}
+Dates in resampled not in raw: {'2005-06-30'}
+File: tasmax_hadukgrid_uk_1km_day_20050801-20050831.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2005-08-31'}
+Dates in resampled not in raw: {'2005-07-30'}
+File: tasmax_hadukgrid_uk_1km_day_20050901-20050930.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'2005-09-30'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_20051001-20051031.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2005-10-31'}
+Dates in resampled not in raw: {'2005-09-30'}
+File: tasmax_hadukgrid_uk_1km_day_20051101-20051130.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'2005-11-30'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_20051201-20051231.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2005-12-31'}
+Dates in resampled not in raw: {'2005-11-30'}
+File: tasmax_hadukgrid_uk_1km_day_20060101-20060131.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2006-01-31'}
+Dates in resampled not in raw: {'2006-02-01'}
+File: tasmax_hadukgrid_uk_1km_day_20060201-20060228.nc produced errors:
+raw # days: 28 - resampled # days: 27
+Dates in raw not in resampled: {'2006-02-01'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_20060301-20060331.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2006-03-30', '2006-03-31'}
+Dates in resampled not in raw: {'2006-02-29', '2006-02-30'}
+File: tasmax_hadukgrid_uk_1km_day_20060401-20060430.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'2006-04-29', '2006-04-30'}
+Dates in resampled not in raw: {'2006-03-30'}
+File: tasmax_hadukgrid_uk_1km_day_20060501-20060531.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2006-05-30', '2006-05-31'}
+Dates in resampled not in raw: {'2006-04-29', '2006-04-30'}
+File: tasmax_hadukgrid_uk_1km_day_20060601-20060630.nc produced errors:
+raw # days: 30 - resampled # days: 30
+Dates in raw not in resampled: {'2006-06-30'}
+Dates in resampled not in raw: {'2006-05-30'}
+File: tasmax_hadukgrid_uk_1km_day_20060701-20060731.nc produced errors:
+raw # days: 31 - resampled # days: 30
+Dates in raw not in resampled: {'2006-07-30', '2006-07-31'}
+Dates in resampled not in raw: {'2006-06-30'}
+File: tasmax_hadukgrid_uk_1km_day_20060801-20060831.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2006-08-31'}
+Dates in resampled not in raw: {'2006-07-30'}
+File: tasmax_hadukgrid_uk_1km_day_20060901-20060930.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'2006-09-30'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_20061001-20061031.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2006-10-31'}
+Dates in resampled not in raw: {'2006-09-30'}
+File: tasmax_hadukgrid_uk_1km_day_20061101-20061130.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'2006-11-30'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_20061201-20061231.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2006-12-31'}
+Dates in resampled not in raw: {'2006-11-30'}
+File: tasmax_hadukgrid_uk_1km_day_20070101-20070131.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2007-01-31'}
+Dates in resampled not in raw: {'2007-02-01'}
+File: tasmax_hadukgrid_uk_1km_day_20070201-20070228.nc produced errors:
+raw # days: 28 - resampled # days: 27
+Dates in raw not in resampled: {'2007-02-01'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_20070301-20070331.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2007-03-30', '2007-03-31'}
+Dates in resampled not in raw: {'2007-02-29', '2007-02-30'}
+File: tasmax_hadukgrid_uk_1km_day_20070401-20070430.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'2007-04-30', '2007-04-29'}
+Dates in resampled not in raw: {'2007-03-30'}
+File: tasmax_hadukgrid_uk_1km_day_20070501-20070531.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2007-05-31', '2007-05-30'}
+Dates in resampled not in raw: {'2007-04-30', '2007-04-29'}
+File: tasmax_hadukgrid_uk_1km_day_20070601-20070630.nc produced errors:
+raw # days: 30 - resampled # days: 30
+Dates in raw not in resampled: {'2007-06-30'}
+Dates in resampled not in raw: {'2007-05-30'}
+File: tasmax_hadukgrid_uk_1km_day_20070701-20070731.nc produced errors:
+raw # days: 31 - resampled # days: 30
+Dates in raw not in resampled: {'2007-07-30', '2007-07-31'}
+Dates in resampled not in raw: {'2007-06-30'}
+File: tasmax_hadukgrid_uk_1km_day_20070801-20070831.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2007-08-31'}
+Dates in resampled not in raw: {'2007-07-30'}
+File: tasmax_hadukgrid_uk_1km_day_20070901-20070930.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'2007-09-30'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_20071001-20071031.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2007-10-31'}
+Dates in resampled not in raw: {'2007-09-30'}
+File: tasmax_hadukgrid_uk_1km_day_20071101-20071130.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'2007-11-30'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_20071201-20071231.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2007-12-31'}
+Dates in resampled not in raw: {'2007-11-30'}
+File: tasmax_hadukgrid_uk_1km_day_20080101-20080131.nc produced errors:
+raw # days: 31 - resampled # days: 30
+Dates in raw not in resampled: {'2008-01-31'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_20080301-20080331.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2008-03-31'}
+Dates in resampled not in raw: {'2008-02-30'}
+File: tasmax_hadukgrid_uk_1km_day_20080401-20080430.nc produced errors:
+raw # days: 30 - resampled # days: 30
+Dates in raw not in resampled: {'2008-04-30'}
+Dates in resampled not in raw: {'2008-03-30'}
+File: tasmax_hadukgrid_uk_1km_day_20080501-20080531.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2008-05-31'}
+Dates in resampled not in raw: {'2008-04-30'}
+File: tasmax_hadukgrid_uk_1km_day_20080601-20080630.nc produced errors:
+raw # days: 30 - resampled # days: 30
+Dates in raw not in resampled: {'2008-06-30'}
+Dates in resampled not in raw: {'2008-05-30'}
+File: tasmax_hadukgrid_uk_1km_day_20080701-20080731.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2008-07-31'}
+Dates in resampled not in raw: {'2008-06-30'}
+File: tasmax_hadukgrid_uk_1km_day_20080801-20080831.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2008-08-31'}
+Dates in resampled not in raw: {'2008-07-30'}
+File: tasmax_hadukgrid_uk_1km_day_20081001-20081031.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2008-10-31'}
+Dates in resampled not in raw: {'2008-09-30'}
+File: tasmax_hadukgrid_uk_1km_day_20081201-20081231.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2008-12-31'}
+Dates in resampled not in raw: {'2008-11-30'}
+File: tasmax_hadukgrid_uk_1km_day_20090101-20090131.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2009-01-31'}
+Dates in resampled not in raw: {'2009-02-01'}
+File: tasmax_hadukgrid_uk_1km_day_20090201-20090228.nc produced errors:
+raw # days: 28 - resampled # days: 27
+Dates in raw not in resampled: {'2009-02-01'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_20090301-20090331.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2009-03-30', '2009-03-31'}
+Dates in resampled not in raw: {'2009-02-30', '2009-02-29'}
+File: tasmax_hadukgrid_uk_1km_day_20090401-20090430.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'2009-04-29', '2009-04-30'}
+Dates in resampled not in raw: {'2009-03-30'}
+File: tasmax_hadukgrid_uk_1km_day_20090501-20090531.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2009-05-30', '2009-05-31'}
+Dates in resampled not in raw: {'2009-04-29', '2009-04-30'}
+File: tasmax_hadukgrid_uk_1km_day_20090601-20090630.nc produced errors:
+raw # days: 30 - resampled # days: 30
+Dates in raw not in resampled: {'2009-06-30'}
+Dates in resampled not in raw: {'2009-05-30'}
+File: tasmax_hadukgrid_uk_1km_day_20090701-20090731.nc produced errors:
+raw # days: 31 - resampled # days: 30
+Dates in raw not in resampled: {'2009-07-30', '2009-07-31'}
+Dates in resampled not in raw: {'2009-06-30'}
+File: tasmax_hadukgrid_uk_1km_day_20090801-20090831.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2009-08-31'}
+Dates in resampled not in raw: {'2009-07-30'}
+File: tasmax_hadukgrid_uk_1km_day_20090901-20090930.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'2009-09-30'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_20091001-20091031.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2009-10-31'}
+Dates in resampled not in raw: {'2009-09-30'}
+File: tasmax_hadukgrid_uk_1km_day_20091101-20091130.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'2009-11-30'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_20091201-20091231.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2009-12-31'}
+Dates in resampled not in raw: {'2009-11-30'}
+File: tasmax_hadukgrid_uk_1km_day_20100101-20100131.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2010-01-31'}
+Dates in resampled not in raw: {'2010-02-01'}
+File: tasmax_hadukgrid_uk_1km_day_20100201-20100228.nc produced errors:
+raw # days: 28 - resampled # days: 27
+Dates in raw not in resampled: {'2010-02-01'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_20100301-20100331.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2010-03-30', '2010-03-31'}
+Dates in resampled not in raw: {'2010-02-29', '2010-02-30'}
+File: tasmax_hadukgrid_uk_1km_day_20100401-20100430.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'2010-04-29', '2010-04-30'}
+Dates in resampled not in raw: {'2010-03-30'}
+File: tasmax_hadukgrid_uk_1km_day_20100501-20100531.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2010-05-30', '2010-05-31'}
+Dates in resampled not in raw: {'2010-04-29', '2010-04-30'}
+File: tasmax_hadukgrid_uk_1km_day_20100601-20100630.nc produced errors:
+raw # days: 30 - resampled # days: 30
+Dates in raw not in resampled: {'2010-06-30'}
+Dates in resampled not in raw: {'2010-05-30'}
+File: tasmax_hadukgrid_uk_1km_day_20100701-20100731.nc produced errors:
+raw # days: 31 - resampled # days: 30
+Dates in raw not in resampled: {'2010-07-30', '2010-07-31'}
+Dates in resampled not in raw: {'2010-06-30'}
+File: tasmax_hadukgrid_uk_1km_day_20100801-20100831.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2010-08-31'}
+Dates in resampled not in raw: {'2010-07-30'}
+File: tasmax_hadukgrid_uk_1km_day_20100901-20100930.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'2010-09-30'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_20101001-20101031.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2010-10-31'}
+Dates in resampled not in raw: {'2010-09-30'}
+File: tasmax_hadukgrid_uk_1km_day_20101101-20101130.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'2010-11-30'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_20101201-20101231.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2010-12-31'}
+Dates in resampled not in raw: {'2010-11-30'}
+File: tasmax_hadukgrid_uk_1km_day_20110101-20110131.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2011-01-31'}
+Dates in resampled not in raw: {'2011-02-01'}
+File: tasmax_hadukgrid_uk_1km_day_20110201-20110228.nc produced errors:
+raw # days: 28 - resampled # days: 27
+Dates in raw not in resampled: {'2011-02-01'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_20110301-20110331.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2011-03-31', '2011-03-30'}
+Dates in resampled not in raw: {'2011-02-29', '2011-02-30'}
+File: tasmax_hadukgrid_uk_1km_day_20110401-20110430.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'2011-04-29', '2011-04-30'}
+Dates in resampled not in raw: {'2011-03-30'}
+File: tasmax_hadukgrid_uk_1km_day_20110501-20110531.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2011-05-30', '2011-05-31'}
+Dates in resampled not in raw: {'2011-04-29', '2011-04-30'}
+File: tasmax_hadukgrid_uk_1km_day_20110601-20110630.nc produced errors:
+raw # days: 30 - resampled # days: 30
+Dates in raw not in resampled: {'2011-06-30'}
+Dates in resampled not in raw: {'2011-05-30'}
+File: tasmax_hadukgrid_uk_1km_day_20110701-20110731.nc produced errors:
+raw # days: 31 - resampled # days: 30
+Dates in raw not in resampled: {'2011-07-30', '2011-07-31'}
+Dates in resampled not in raw: {'2011-06-30'}
+File: tasmax_hadukgrid_uk_1km_day_20110801-20110831.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2011-08-31'}
+Dates in resampled not in raw: {'2011-07-30'}
+File: tasmax_hadukgrid_uk_1km_day_20110901-20110930.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'2011-09-30'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_20111001-20111031.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2011-10-31'}
+Dates in resampled not in raw: {'2011-09-30'}
+File: tasmax_hadukgrid_uk_1km_day_20111101-20111130.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'2011-11-30'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_20111201-20111231.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2011-12-31'}
+Dates in resampled not in raw: {'2011-11-30'}
+File: tasmax_hadukgrid_uk_1km_day_20120101-20120131.nc produced errors:
+raw # days: 31 - resampled # days: 30
+Dates in raw not in resampled: {'2012-01-31'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_20120301-20120331.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2012-03-31'}
+Dates in resampled not in raw: {'2012-02-30'}
+File: tasmax_hadukgrid_uk_1km_day_20120401-20120430.nc produced errors:
+raw # days: 30 - resampled # days: 30
+Dates in raw not in resampled: {'2012-04-30'}
+Dates in resampled not in raw: {'2012-03-30'}
+File: tasmax_hadukgrid_uk_1km_day_20120501-20120531.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2012-05-31'}
+Dates in resampled not in raw: {'2012-04-30'}
+File: tasmax_hadukgrid_uk_1km_day_20120601-20120630.nc produced errors:
+raw # days: 30 - resampled # days: 30
+Dates in raw not in resampled: {'2012-06-30'}
+Dates in resampled not in raw: {'2012-05-30'}
+File: tasmax_hadukgrid_uk_1km_day_20120701-20120731.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2012-07-31'}
+Dates in resampled not in raw: {'2012-06-30'}
+File: tasmax_hadukgrid_uk_1km_day_20120801-20120831.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2012-08-31'}
+Dates in resampled not in raw: {'2012-07-30'}
+File: tasmax_hadukgrid_uk_1km_day_20121001-20121031.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2012-10-31'}
+Dates in resampled not in raw: {'2012-09-30'}
+File: tasmax_hadukgrid_uk_1km_day_20121201-20121231.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2012-12-31'}
+Dates in resampled not in raw: {'2012-11-30'}
+File: tasmax_hadukgrid_uk_1km_day_20130101-20130131.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2013-01-31'}
+Dates in resampled not in raw: {'2013-02-01'}
+File: tasmax_hadukgrid_uk_1km_day_20130201-20130228.nc produced errors:
+raw # days: 28 - resampled # days: 27
+Dates in raw not in resampled: {'2013-02-01'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_20130301-20130331.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2013-03-30', '2013-03-31'}
+Dates in resampled not in raw: {'2013-02-29', '2013-02-30'}
+File: tasmax_hadukgrid_uk_1km_day_20130401-20130430.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'2013-04-29', '2013-04-30'}
+Dates in resampled not in raw: {'2013-03-30'}
+File: tasmax_hadukgrid_uk_1km_day_20130501-20130531.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2013-05-30', '2013-05-31'}
+Dates in resampled not in raw: {'2013-04-29', '2013-04-30'}
+File: tasmax_hadukgrid_uk_1km_day_20130601-20130630.nc produced errors:
+raw # days: 30 - resampled # days: 30
+Dates in raw not in resampled: {'2013-06-30'}
+Dates in resampled not in raw: {'2013-05-30'}
+File: tasmax_hadukgrid_uk_1km_day_20130701-20130731.nc produced errors:
+raw # days: 31 - resampled # days: 30
+Dates in raw not in resampled: {'2013-07-30', '2013-07-31'}
+Dates in resampled not in raw: {'2013-06-30'}
+File: tasmax_hadukgrid_uk_1km_day_20130801-20130831.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2013-08-31'}
+Dates in resampled not in raw: {'2013-07-30'}
+File: tasmax_hadukgrid_uk_1km_day_20130901-20130930.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'2013-09-30'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_20131001-20131031.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2013-10-31'}
+Dates in resampled not in raw: {'2013-09-30'}
+File: tasmax_hadukgrid_uk_1km_day_20131101-20131130.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'2013-11-30'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_20131201-20131231.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2013-12-31'}
+Dates in resampled not in raw: {'2013-11-30'}
+File: tasmax_hadukgrid_uk_1km_day_20140101-20140131.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2014-01-31'}
+Dates in resampled not in raw: {'2014-02-01'}
+File: tasmax_hadukgrid_uk_1km_day_20140201-20140228.nc produced errors:
+raw # days: 28 - resampled # days: 27
+Dates in raw not in resampled: {'2014-02-01'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_20140301-20140331.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2014-03-31', '2014-03-30'}
+Dates in resampled not in raw: {'2014-02-30', '2014-02-29'}
+File: tasmax_hadukgrid_uk_1km_day_20140401-20140430.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'2014-04-29', '2014-04-30'}
+Dates in resampled not in raw: {'2014-03-30'}
+File: tasmax_hadukgrid_uk_1km_day_20140501-20140531.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2014-05-31', '2014-05-30'}
+Dates in resampled not in raw: {'2014-04-29', '2014-04-30'}
+File: tasmax_hadukgrid_uk_1km_day_20140601-20140630.nc produced errors:
+raw # days: 30 - resampled # days: 30
+Dates in raw not in resampled: {'2014-06-30'}
+Dates in resampled not in raw: {'2014-05-30'}
+File: tasmax_hadukgrid_uk_1km_day_20140701-20140731.nc produced errors:
+raw # days: 31 - resampled # days: 30
+Dates in raw not in resampled: {'2014-07-30', '2014-07-31'}
+Dates in resampled not in raw: {'2014-06-30'}
+File: tasmax_hadukgrid_uk_1km_day_20140801-20140831.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2014-08-31'}
+Dates in resampled not in raw: {'2014-07-30'}
+File: tasmax_hadukgrid_uk_1km_day_20140901-20140930.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'2014-09-30'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_20141001-20141031.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2014-10-31'}
+Dates in resampled not in raw: {'2014-09-30'}
+File: tasmax_hadukgrid_uk_1km_day_20141101-20141130.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'2014-11-30'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_20141201-20141231.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2014-12-31'}
+Dates in resampled not in raw: {'2014-11-30'}
+File: tasmax_hadukgrid_uk_1km_day_20150101-20150131.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2015-01-31'}
+Dates in resampled not in raw: {'2015-02-01'}
+File: tasmax_hadukgrid_uk_1km_day_20150201-20150228.nc produced errors:
+raw # days: 28 - resampled # days: 27
+Dates in raw not in resampled: {'2015-02-01'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_20150301-20150331.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2015-03-30', '2015-03-31'}
+Dates in resampled not in raw: {'2015-02-30', '2015-02-29'}
+File: tasmax_hadukgrid_uk_1km_day_20150401-20150430.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'2015-04-30', '2015-04-29'}
+Dates in resampled not in raw: {'2015-03-30'}
+File: tasmax_hadukgrid_uk_1km_day_20150501-20150531.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2015-05-30', '2015-05-31'}
+Dates in resampled not in raw: {'2015-04-30', '2015-04-29'}
+File: tasmax_hadukgrid_uk_1km_day_20150601-20150630.nc produced errors:
+raw # days: 30 - resampled # days: 30
+Dates in raw not in resampled: {'2015-06-30'}
+Dates in resampled not in raw: {'2015-05-30'}
+File: tasmax_hadukgrid_uk_1km_day_20150701-20150731.nc produced errors:
+raw # days: 31 - resampled # days: 30
+Dates in raw not in resampled: {'2015-07-30', '2015-07-31'}
+Dates in resampled not in raw: {'2015-06-30'}
+File: tasmax_hadukgrid_uk_1km_day_20150801-20150831.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2015-08-31'}
+Dates in resampled not in raw: {'2015-07-30'}
+File: tasmax_hadukgrid_uk_1km_day_20150901-20150930.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'2015-09-30'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_20151001-20151031.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2015-10-31'}
+Dates in resampled not in raw: {'2015-09-30'}
+File: tasmax_hadukgrid_uk_1km_day_20151101-20151130.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'2015-11-30'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_20151201-20151231.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2015-12-31'}
+Dates in resampled not in raw: {'2015-11-30'}
+File: tasmax_hadukgrid_uk_1km_day_20160101-20160131.nc produced errors:
+raw # days: 31 - resampled # days: 30
+Dates in raw not in resampled: {'2016-01-31'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_20160301-20160331.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2016-03-31'}
+Dates in resampled not in raw: {'2016-02-30'}
+File: tasmax_hadukgrid_uk_1km_day_20160401-20160430.nc produced errors:
+raw # days: 30 - resampled # days: 30
+Dates in raw not in resampled: {'2016-04-30'}
+Dates in resampled not in raw: {'2016-03-30'}
+File: tasmax_hadukgrid_uk_1km_day_20160501-20160531.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2016-05-31'}
+Dates in resampled not in raw: {'2016-04-30'}
+File: tasmax_hadukgrid_uk_1km_day_20160601-20160630.nc produced errors:
+raw # days: 30 - resampled # days: 30
+Dates in raw not in resampled: {'2016-06-30'}
+Dates in resampled not in raw: {'2016-05-30'}
+File: tasmax_hadukgrid_uk_1km_day_20160701-20160731.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2016-07-31'}
+Dates in resampled not in raw: {'2016-06-30'}
+File: tasmax_hadukgrid_uk_1km_day_20160801-20160831.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2016-08-31'}
+Dates in resampled not in raw: {'2016-07-30'}
+File: tasmax_hadukgrid_uk_1km_day_20161001-20161031.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2016-10-31'}
+Dates in resampled not in raw: {'2016-09-30'}
+File: tasmax_hadukgrid_uk_1km_day_20161201-20161231.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2016-12-31'}
+Dates in resampled not in raw: {'2016-11-30'}
+File: tasmax_hadukgrid_uk_1km_day_20170101-20170131.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2017-01-31'}
+Dates in resampled not in raw: {'2017-02-01'}
+File: tasmax_hadukgrid_uk_1km_day_20170201-20170228.nc produced errors:
+raw # days: 28 - resampled # days: 27
+Dates in raw not in resampled: {'2017-02-01'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_20170301-20170331.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2017-03-31', '2017-03-30'}
+Dates in resampled not in raw: {'2017-02-29', '2017-02-30'}
+File: tasmax_hadukgrid_uk_1km_day_20170401-20170430.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'2017-04-30', '2017-04-29'}
+Dates in resampled not in raw: {'2017-03-30'}
+File: tasmax_hadukgrid_uk_1km_day_20170501-20170531.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2017-05-30', '2017-05-31'}
+Dates in resampled not in raw: {'2017-04-30', '2017-04-29'}
+File: tasmax_hadukgrid_uk_1km_day_20170601-20170630.nc produced errors:
+raw # days: 30 - resampled # days: 30
+Dates in raw not in resampled: {'2017-06-30'}
+Dates in resampled not in raw: {'2017-05-30'}
+File: tasmax_hadukgrid_uk_1km_day_20170701-20170731.nc produced errors:
+raw # days: 31 - resampled # days: 30
+Dates in raw not in resampled: {'2017-07-30', '2017-07-31'}
+Dates in resampled not in raw: {'2017-06-30'}
+File: tasmax_hadukgrid_uk_1km_day_20170801-20170831.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2017-08-31'}
+Dates in resampled not in raw: {'2017-07-30'}
+File: tasmax_hadukgrid_uk_1km_day_20170901-20170930.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'2017-09-30'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_20171001-20171031.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2017-10-31'}
+Dates in resampled not in raw: {'2017-09-30'}
+File: tasmax_hadukgrid_uk_1km_day_20171101-20171130.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'2017-11-30'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_20171201-20171231.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2017-12-31'}
+Dates in resampled not in raw: {'2017-11-30'}
+File: tasmax_hadukgrid_uk_1km_day_20180101-20180131.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2018-01-31'}
+Dates in resampled not in raw: {'2018-02-01'}
+File: tasmax_hadukgrid_uk_1km_day_20180201-20180228.nc produced errors:
+raw # days: 28 - resampled # days: 27
+Dates in raw not in resampled: {'2018-02-01'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_20180301-20180331.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2018-03-30', '2018-03-31'}
+Dates in resampled not in raw: {'2018-02-29', '2018-02-30'}
+File: tasmax_hadukgrid_uk_1km_day_20180401-20180430.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'2018-04-29', '2018-04-30'}
+Dates in resampled not in raw: {'2018-03-30'}
+File: tasmax_hadukgrid_uk_1km_day_20180501-20180531.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2018-05-30', '2018-05-31'}
+Dates in resampled not in raw: {'2018-04-29', '2018-04-30'}
+File: tasmax_hadukgrid_uk_1km_day_20180601-20180630.nc produced errors:
+raw # days: 30 - resampled # days: 30
+Dates in raw not in resampled: {'2018-06-30'}
+Dates in resampled not in raw: {'2018-05-30'}
+File: tasmax_hadukgrid_uk_1km_day_20180701-20180731.nc produced errors:
+raw # days: 31 - resampled # days: 30
+Dates in raw not in resampled: {'2018-07-31', '2018-07-30'}
+Dates in resampled not in raw: {'2018-06-30'}
+File: tasmax_hadukgrid_uk_1km_day_20180801-20180831.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2018-08-31'}
+Dates in resampled not in raw: {'2018-07-30'}
+File: tasmax_hadukgrid_uk_1km_day_20180901-20180930.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'2018-09-30'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_20181001-20181031.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2018-10-31'}
+Dates in resampled not in raw: {'2018-09-30'}
+File: tasmax_hadukgrid_uk_1km_day_20181101-20181130.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'2018-11-30'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_20181201-20181231.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2018-12-31'}
+Dates in resampled not in raw: {'2018-11-30'}
+File: tasmax_hadukgrid_uk_1km_day_20190101-20190131.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2019-01-31'}
+Dates in resampled not in raw: {'2019-02-01'}
+File: tasmax_hadukgrid_uk_1km_day_20190201-20190228.nc produced errors:
+raw # days: 28 - resampled # days: 27
+Dates in raw not in resampled: {'2019-02-01'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_20190301-20190331.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2019-03-30', '2019-03-31'}
+Dates in resampled not in raw: {'2019-02-30', '2019-02-29'}
+File: tasmax_hadukgrid_uk_1km_day_20190401-20190430.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'2019-04-29', '2019-04-30'}
+Dates in resampled not in raw: {'2019-03-30'}
+File: tasmax_hadukgrid_uk_1km_day_20190501-20190531.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2019-05-30', '2019-05-31'}
+Dates in resampled not in raw: {'2019-04-29', '2019-04-30'}
+File: tasmax_hadukgrid_uk_1km_day_20190601-20190630.nc produced errors:
+raw # days: 30 - resampled # days: 30
+Dates in raw not in resampled: {'2019-06-30'}
+Dates in resampled not in raw: {'2019-05-30'}
+File: tasmax_hadukgrid_uk_1km_day_20190701-20190731.nc produced errors:
+raw # days: 31 - resampled # days: 30
+Dates in raw not in resampled: {'2019-07-31', '2019-07-30'}
+Dates in resampled not in raw: {'2019-06-30'}
+File: tasmax_hadukgrid_uk_1km_day_20190801-20190831.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2019-08-31'}
+Dates in resampled not in raw: {'2019-07-30'}
+File: tasmax_hadukgrid_uk_1km_day_20190901-20190930.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'2019-09-30'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_20191001-20191031.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2019-10-31'}
+Dates in resampled not in raw: {'2019-09-30'}
+File: tasmax_hadukgrid_uk_1km_day_20191101-20191130.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'2019-11-30'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_20191201-20191231.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2019-12-31'}
+Dates in resampled not in raw: {'2019-11-30'}
+File: tasmax_hadukgrid_uk_1km_day_20200101-20200131.nc produced errors:
+raw # days: 31 - resampled # days: 30
+Dates in raw not in resampled: {'2020-01-31'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_20200301-20200331.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2020-03-31'}
+Dates in resampled not in raw: {'2020-02-30'}
+File: tasmax_hadukgrid_uk_1km_day_20200401-20200430.nc produced errors:
+raw # days: 30 - resampled # days: 30
+Dates in raw not in resampled: {'2020-04-30'}
+Dates in resampled not in raw: {'2020-03-30'}
+File: tasmax_hadukgrid_uk_1km_day_20200501-20200531.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2020-05-31'}
+Dates in resampled not in raw: {'2020-04-30'}
+File: tasmax_hadukgrid_uk_1km_day_20200601-20200630.nc produced errors:
+raw # days: 30 - resampled # days: 30
+Dates in raw not in resampled: {'2020-06-30'}
+Dates in resampled not in raw: {'2020-05-30'}
+File: tasmax_hadukgrid_uk_1km_day_20200701-20200731.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2020-07-31'}
+Dates in resampled not in raw: {'2020-06-30'}
+File: tasmax_hadukgrid_uk_1km_day_20200801-20200831.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2020-08-31'}
+Dates in resampled not in raw: {'2020-07-30'}
+File: tasmax_hadukgrid_uk_1km_day_20201001-20201031.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2020-10-31'}
+Dates in resampled not in raw: {'2020-09-30'}
+File: tasmax_hadukgrid_uk_1km_day_20201201-20201231.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2020-12-31'}
+Dates in resampled not in raw: {'2020-11-30'}
+File: tasmax_hadukgrid_uk_1km_day_20210101-20210131.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2021-01-31'}
+Dates in resampled not in raw: {'2021-02-01'}
+File: tasmax_hadukgrid_uk_1km_day_20210201-20210228.nc produced errors:
+raw # days: 28 - resampled # days: 27
+Dates in raw not in resampled: {'2021-02-01'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_20210301-20210331.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2021-03-31', '2021-03-30'}
+Dates in resampled not in raw: {'2021-02-30', '2021-02-29'}
+File: tasmax_hadukgrid_uk_1km_day_20210401-20210430.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'2021-04-29', '2021-04-30'}
+Dates in resampled not in raw: {'2021-03-30'}
+File: tasmax_hadukgrid_uk_1km_day_20210501-20210531.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2021-05-31', '2021-05-30'}
+Dates in resampled not in raw: {'2021-04-29', '2021-04-30'}
+File: tasmax_hadukgrid_uk_1km_day_20210601-20210630.nc produced errors:
+raw # days: 30 - resampled # days: 30
+Dates in raw not in resampled: {'2021-06-30'}
+Dates in resampled not in raw: {'2021-05-30'}
+File: tasmax_hadukgrid_uk_1km_day_20210701-20210731.nc produced errors:
+raw # days: 31 - resampled # days: 30
+Dates in raw not in resampled: {'2021-07-30', '2021-07-31'}
+Dates in resampled not in raw: {'2021-06-30'}
+File: tasmax_hadukgrid_uk_1km_day_20210801-20210831.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2021-08-31'}
+Dates in resampled not in raw: {'2021-07-30'}
+File: tasmax_hadukgrid_uk_1km_day_20210901-20210930.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'2021-09-30'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_20211001-20211031.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2021-10-31'}
+Dates in resampled not in raw: {'2021-09-30'}
+File: tasmax_hadukgrid_uk_1km_day_20211101-20211130.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'2021-11-30'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_20211201-20211231.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2021-12-31'}
+Dates in resampled not in raw: {'2021-11-30'}
+______________________________
+missing dates: 0
+date '1980-03-30' appears 2 times.
+date '1980-05-30' appears 2 times.
+date '1980-07-30' appears 2 times.
+date '1980-09-30' appears 2 times.
+date '1980-11-30' appears 2 times.
+date '1984-03-30' appears 2 times.
+date '1984-05-30' appears 2 times.
+date '1984-07-30' appears 2 times.
+date '1984-09-30' appears 2 times.
+date '1984-11-30' appears 2 times.
+date '1988-03-30' appears 2 times.
+date '1988-05-30' appears 2 times.
+date '1988-07-30' appears 2 times.
+date '1988-09-30' appears 2 times.
+date '1988-11-30' appears 2 times.
+date '1992-03-30' appears 2 times.
+date '1992-05-30' appears 2 times.
+date '1992-07-30' appears 2 times.
+date '1992-09-30' appears 2 times.
+date '1992-11-30' appears 2 times.
+date '1996-03-30' appears 2 times.
+date '1996-05-30' appears 2 times.
+date '1996-07-30' appears 2 times.
+date '1996-09-30' appears 2 times.
+date '1996-11-30' appears 2 times.
+date '2000-03-30' appears 2 times.
+date '2000-05-30' appears 2 times.
+date '2000-07-30' appears 2 times.
+date '2000-09-30' appears 2 times.
+date '2000-11-30' appears 2 times.
+date '2004-03-30' appears 2 times.
+date '2004-05-30' appears 2 times.
+date '2004-07-30' appears 2 times.
+date '2004-09-30' appears 2 times.
+date '2004-11-30' appears 2 times.
+date '2008-03-30' appears 2 times.
+date '2008-05-30' appears 2 times.
+date '2008-07-30' appears 2 times.
+date '2008-09-30' appears 2 times.
+date '2008-11-30' appears 2 times.
+date '2012-03-30' appears 2 times.
+date '2012-05-30' appears 2 times.
+date '2012-07-30' appears 2 times.
+date '2012-09-30' appears 2 times.
+date '2012-11-30' appears 2 times.
+date '2016-03-30' appears 2 times.
+date '2016-05-30' appears 2 times.
+date '2016-07-30' appears 2 times.
+date '2016-09-30' appears 2 times.
+date '2016-11-30' appears 2 times.
+date '2020-03-30' appears 2 times.
+date '2020-05-30' appears 2 times.
+date '2020-07-30' appears 2 times.
+date '2020-09-30' appears 2 times.
+date '2020-11-30' appears 2 times.

--- a/python/resampling/check_calendar.py
+++ b/python/resampling/check_calendar.py
@@ -1,0 +1,58 @@
+from datetime import datetime
+import os
+import xarray as xr
+import glob
+import numpy as np
+
+path_raw = '/Volumes/vmfileshare/ClimateData/Raw/HadsUKgrid/tasmax/day'
+path_preproc = '/Volumes/vmfileshare/ClimateData/Processed/HadsUKgrid/resampled_2.2km/tasmax/day'
+#example file names:
+#tasmax_hadukgrid_uk_1km_day_2.2km_resampled_19800101-19800131.ncr
+#tasmax_hadukgrid_uk_1km_day_20211201-20211231.nc
+
+# open log file and write both input paths on top:
+with open('check_calendar_log.txt', 'w') as f:
+    f.write(f"{'*'*20} Comparing raw data:  {path_raw} {'*'*20}\n")
+    f.write(f"{'*'*20} to resampled data: {path_preproc} {'*'*20}\n")
+
+#iterate through dir at path and loop through files
+files = [os.path.basename(f) for f in glob.glob(path_raw + "**/*.nc", recursive=True)]
+
+for i,file in enumerate(files):
+    if i%10==0:
+        print(i)
+    #separate filename from flag '2.2km_resamples' from date
+    output_name = f"{'_'.join(file.split('_')[:-1])}_2.2km_resampled_{file.split('_')[-1]}"
+
+    raw_f = os.path.join(path_raw, file)
+    preproc_f = os.path.join(path_preproc, output_name)
+    #load before and after resampling files
+    data_raw = xr.open_dataset(raw_f, decode_coords="all")
+    data_preproc = xr.open_dataset(preproc_f, decode_coords="all")
+    time_raw = [str(t).split('T')[0] for t in data_raw.coords['time'].values]
+    time_pre = [str(t).split(' ')[0] for t in data_preproc.coords['time'].values]
+
+    # Use sets to find differences
+    dates_in_raw_not_in_pre = set(time_raw) - set(time_pre)
+    dates_in_pre_not_in_raw = set(time_pre) - set(time_raw)
+
+    # check if dates are empty
+    if dates_in_raw_not_in_pre | dates_in_pre_not_in_raw:
+        #if date in raw not in pre ends in 31
+        if list(dates_in_raw_not_in_pre)[0][-2:]!='31':
+            # write to log file
+            with open(os.path.join(path_preproc,'check_calendar_log.txt'), 'a') as f:
+                f.write(f"File: {file} produced errors:\n")
+                f.write(f"raw # days: {len(set(time_raw))} - resampled # days: {len(set(time_pre))}\n")
+                f.write(f"Dates in raw not in resampled: {dates_in_raw_not_in_pre}\n")
+                f.write(f"Dates in resampled not in raw: {dates_in_pre_not_in_raw}\n")
+
+
+
+
+
+
+
+
+
+

--- a/python/resampling/check_calendar.py
+++ b/python/resampling/check_calendar.py
@@ -4,9 +4,6 @@ import glob
 import numpy as np
 from collections import Counter
 
-path_ukcp = '/Volumes/vmfileshare/ClimateData/Raw/UKCP2.2/tasmax/01/latest/tasmax_rcp85_land-cpm_uk_2.2km_01_day_19801201-19811130.nc'
-data_raw = xr.open_dataset(path_ukcp, decode_coords="all")
-
 path_raw = '/Volumes/vmfileshare/ClimateData/Raw/HadsUKgrid/tasmax/day'
 path_preproc = '/Volumes/vmfileshare/ClimateData/Processed/HadsUKgrid/resampled_2.2km/tasmax/day'
 #example files to be compared :
@@ -29,8 +26,14 @@ for i,file in enumerate(files):
     raw_f = os.path.join(path_raw, file)
     preproc_f = os.path.join(path_preproc, output_name)
     #load before and after resampling files
-    data_raw = xr.open_dataset(raw_f, decode_coords="all")
-    data_preproc = xr.open_dataset(preproc_f, decode_coords="all")
+    try:
+        data_raw = xr.open_dataset(raw_f, decode_coords="all")
+        data_preproc = xr.open_dataset(preproc_f, decode_coords="all")
+    # catch OSError and KeyError
+    except (OSError, KeyError) as e:
+        with open('check_calendar_log.txt', 'a') as f:
+            f.write(f"File: {file} produced errors: {e}\n")
+        continue
 
     #convert to string
     time_raw = [str(t).split('T')[0] for t in data_raw.coords['time'].values]
@@ -44,7 +47,6 @@ for i,file in enumerate(files):
     if dates_in_raw_not_in_pre | dates_in_pre_not_in_raw:
         # write to log file
         with open('check_calendar_log.txt', 'a') as f:
-            f.write(f"File: {file} produced errors:\n")
             f.write(f"raw # days: {len(set(time_raw))} - resampled # days: {len(set(time_pre))}\n")
             f.write(f"Dates in raw not in resampled: {dates_in_raw_not_in_pre}\n")
             f.write(f"Dates in resampled not in raw: {dates_in_pre_not_in_raw}\n")

--- a/python/resampling/check_calendar.py
+++ b/python/resampling/check_calendar.py
@@ -1,14 +1,17 @@
-from datetime import datetime
 import os
 import xarray as xr
 import glob
 import numpy as np
+from collections import Counter
+
+path_ukcp = '/Volumes/vmfileshare/ClimateData/Raw/UKCP2.2/tasmax/01/latest/tasmax_rcp85_land-cpm_uk_2.2km_01_day_19801201-19811130.nc'
+data_raw = xr.open_dataset(path_ukcp, decode_coords="all")
 
 path_raw = '/Volumes/vmfileshare/ClimateData/Raw/HadsUKgrid/tasmax/day'
 path_preproc = '/Volumes/vmfileshare/ClimateData/Processed/HadsUKgrid/resampled_2.2km/tasmax/day'
-#example file names:
-#tasmax_hadukgrid_uk_1km_day_2.2km_resampled_19800101-19800131.ncr
-#tasmax_hadukgrid_uk_1km_day_20211201-20211231.nc
+#example files to be compared :
+# after resampling: tasmax_hadukgrid_uk_1km_day_2.2km_resampled_19800101-19800131.ncr
+# before resampling: tasmax_hadukgrid_uk_1km_day_20211201-20211231.nc
 
 # open log file and write both input paths on top:
 with open('check_calendar_log.txt', 'w') as f:
@@ -18,9 +21,8 @@ with open('check_calendar_log.txt', 'w') as f:
 #iterate through dir at path and loop through files
 files = [os.path.basename(f) for f in glob.glob(path_raw + "**/*.nc", recursive=True)]
 
+all_dates = np.array([], dtype='datetime64[ns]')  # Specify the correct data type
 for i,file in enumerate(files):
-    if i%10==0:
-        print(i)
     #separate filename from flag '2.2km_resamples' from date
     output_name = f"{'_'.join(file.split('_')[:-1])}_2.2km_resampled_{file.split('_')[-1]}"
 
@@ -29,6 +31,8 @@ for i,file in enumerate(files):
     #load before and after resampling files
     data_raw = xr.open_dataset(raw_f, decode_coords="all")
     data_preproc = xr.open_dataset(preproc_f, decode_coords="all")
+
+    #convert to string
     time_raw = [str(t).split('T')[0] for t in data_raw.coords['time'].values]
     time_pre = [str(t).split(' ')[0] for t in data_preproc.coords['time'].values]
 
@@ -38,15 +42,34 @@ for i,file in enumerate(files):
 
     # check if dates are empty
     if dates_in_raw_not_in_pre | dates_in_pre_not_in_raw:
-        #if date in raw not in pre ends in 31
-        if list(dates_in_raw_not_in_pre)[0][-2:]!='31':
-            # write to log file
-            with open(os.path.join(path_preproc,'check_calendar_log.txt'), 'a') as f:
-                f.write(f"File: {file} produced errors:\n")
-                f.write(f"raw # days: {len(set(time_raw))} - resampled # days: {len(set(time_pre))}\n")
-                f.write(f"Dates in raw not in resampled: {dates_in_raw_not_in_pre}\n")
-                f.write(f"Dates in resampled not in raw: {dates_in_pre_not_in_raw}\n")
+        # write to log file
+        with open('check_calendar_log.txt', 'a') as f:
+            f.write(f"File: {file} produced errors:\n")
+            f.write(f"raw # days: {len(set(time_raw))} - resampled # days: {len(set(time_pre))}\n")
+            f.write(f"Dates in raw not in resampled: {dates_in_raw_not_in_pre}\n")
+            f.write(f"Dates in resampled not in raw: {dates_in_pre_not_in_raw}\n")
 
+    # save dates for later overall comparison
+    all_dates = np.concatenate((all_dates, data_preproc.coords['time'].values))
+
+# generating expected dates
+start = files[0].split('_')[-1].split('-')[0]
+stop = files[-1].split('_')[-1].split('-')[1][:-5]+'30'
+time_index = xr.cftime_range(start, stop, freq='D', calendar='360_day', inclusive='both')
+
+# convert to strings
+x_dates_str = [f"{date.year}-{date.month:02d}-{date.day:02d}" for date in time_index]
+y_dates_str = [f"{date.year}-{date.month:02d}-{date.day:02d}" for date in all_dates]
+# compare if all present
+not_in_y = [date_x for date_x in x_dates_str if date_x not in y_dates_str]
+with open('check_calendar_log.txt', 'a') as f:
+            f.write(f'______________________________\n')
+            f.write(f'missing dates: {len(not_in_y)}\n')
+            # find duplicates
+            counts = Counter(y_dates_str)
+            for string, count in counts.items():
+                if count > 1:
+                    f.write(f"date '{string}' appears {count} times.\n")
 
 
 

--- a/python/resampling/check_calendar_log.txt
+++ b/python/resampling/check_calendar_log.txt
@@ -1,0 +1,1886 @@
+******************** Comparing raw data:  /Volumes/vmfileshare/ClimateData/Raw/HadsUKgrid/tasmax/day ********************
+******************** to resampled data: /Volumes/vmfileshare/ClimateData/Processed/HadsUKgrid/resampled_2.2km/tasmax/day ********************
+File: tasmax_hadukgrid_uk_1km_day_19800101-19800131.nc produced errors:
+raw # days: 31 - resampled # days: 30
+Dates in raw not in resampled: {'1980-01-31'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_19800301-19800331.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1980-03-31'}
+Dates in resampled not in raw: {'1980-02-30'}
+File: tasmax_hadukgrid_uk_1km_day_19800401-19800430.nc produced errors:
+raw # days: 30 - resampled # days: 30
+Dates in raw not in resampled: {'1980-04-30'}
+Dates in resampled not in raw: {'1980-03-30'}
+File: tasmax_hadukgrid_uk_1km_day_19800501-19800531.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1980-05-31'}
+Dates in resampled not in raw: {'1980-04-30'}
+File: tasmax_hadukgrid_uk_1km_day_19800601-19800630.nc produced errors:
+raw # days: 30 - resampled # days: 30
+Dates in raw not in resampled: {'1980-06-30'}
+Dates in resampled not in raw: {'1980-05-30'}
+File: tasmax_hadukgrid_uk_1km_day_19800701-19800731.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1980-07-31'}
+Dates in resampled not in raw: {'1980-06-30'}
+File: tasmax_hadukgrid_uk_1km_day_19800801-19800831.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1980-08-31'}
+Dates in resampled not in raw: {'1980-07-30'}
+File: tasmax_hadukgrid_uk_1km_day_19801001-19801031.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1980-10-31'}
+Dates in resampled not in raw: {'1980-09-30'}
+File: tasmax_hadukgrid_uk_1km_day_19801201-19801231.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1980-12-31'}
+Dates in resampled not in raw: {'1980-11-30'}
+File: tasmax_hadukgrid_uk_1km_day_19810101-19810131.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1981-01-31'}
+Dates in resampled not in raw: {'1981-02-01'}
+File: tasmax_hadukgrid_uk_1km_day_19810201-19810228.nc produced errors:
+raw # days: 28 - resampled # days: 27
+Dates in raw not in resampled: {'1981-02-01'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_19810301-19810331.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1981-03-31', '1981-03-30'}
+Dates in resampled not in raw: {'1981-02-29', '1981-02-30'}
+File: tasmax_hadukgrid_uk_1km_day_19810401-19810430.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'1981-04-30', '1981-04-29'}
+Dates in resampled not in raw: {'1981-03-30'}
+File: tasmax_hadukgrid_uk_1km_day_19810501-19810531.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1981-05-31', '1981-05-30'}
+Dates in resampled not in raw: {'1981-04-30', '1981-04-29'}
+File: tasmax_hadukgrid_uk_1km_day_19810601-19810630.nc produced errors:
+raw # days: 30 - resampled # days: 30
+Dates in raw not in resampled: {'1981-06-30'}
+Dates in resampled not in raw: {'1981-05-30'}
+File: tasmax_hadukgrid_uk_1km_day_19810701-19810731.nc produced errors:
+raw # days: 31 - resampled # days: 30
+Dates in raw not in resampled: {'1981-07-31', '1981-07-30'}
+Dates in resampled not in raw: {'1981-06-30'}
+File: tasmax_hadukgrid_uk_1km_day_19810801-19810831.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1981-08-31'}
+Dates in resampled not in raw: {'1981-07-30'}
+File: tasmax_hadukgrid_uk_1km_day_19810901-19810930.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'1981-09-30'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_19811001-19811031.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1981-10-31'}
+Dates in resampled not in raw: {'1981-09-30'}
+File: tasmax_hadukgrid_uk_1km_day_19811101-19811130.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'1981-11-30'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_19811201-19811231.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1981-12-31'}
+Dates in resampled not in raw: {'1981-11-30'}
+File: tasmax_hadukgrid_uk_1km_day_19820101-19820131.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1982-01-31'}
+Dates in resampled not in raw: {'1982-02-01'}
+File: tasmax_hadukgrid_uk_1km_day_19820201-19820228.nc produced errors:
+raw # days: 28 - resampled # days: 27
+Dates in raw not in resampled: {'1982-02-01'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_19820301-19820331.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1982-03-30', '1982-03-31'}
+Dates in resampled not in raw: {'1982-02-30', '1982-02-29'}
+File: tasmax_hadukgrid_uk_1km_day_19820401-19820430.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'1982-04-29', '1982-04-30'}
+Dates in resampled not in raw: {'1982-03-30'}
+File: tasmax_hadukgrid_uk_1km_day_19820501-19820531.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1982-05-31', '1982-05-30'}
+Dates in resampled not in raw: {'1982-04-29', '1982-04-30'}
+File: tasmax_hadukgrid_uk_1km_day_19820601-19820630.nc produced errors:
+raw # days: 30 - resampled # days: 30
+Dates in raw not in resampled: {'1982-06-30'}
+Dates in resampled not in raw: {'1982-05-30'}
+File: tasmax_hadukgrid_uk_1km_day_19820701-19820731.nc produced errors:
+raw # days: 31 - resampled # days: 30
+Dates in raw not in resampled: {'1982-07-30', '1982-07-31'}
+Dates in resampled not in raw: {'1982-06-30'}
+File: tasmax_hadukgrid_uk_1km_day_19820801-19820831.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1982-08-31'}
+Dates in resampled not in raw: {'1982-07-30'}
+File: tasmax_hadukgrid_uk_1km_day_19820901-19820930.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'1982-09-30'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_19821001-19821031.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1982-10-31'}
+Dates in resampled not in raw: {'1982-09-30'}
+File: tasmax_hadukgrid_uk_1km_day_19821101-19821130.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'1982-11-30'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_19821201-19821231.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1982-12-31'}
+Dates in resampled not in raw: {'1982-11-30'}
+File: tasmax_hadukgrid_uk_1km_day_19830101-19830131.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1983-01-31'}
+Dates in resampled not in raw: {'1983-02-01'}
+File: tasmax_hadukgrid_uk_1km_day_19830201-19830228.nc produced errors:
+raw # days: 28 - resampled # days: 27
+Dates in raw not in resampled: {'1983-02-01'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_19830301-19830331.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1983-03-30', '1983-03-31'}
+Dates in resampled not in raw: {'1983-02-29', '1983-02-30'}
+File: tasmax_hadukgrid_uk_1km_day_19830401-19830430.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'1983-04-29', '1983-04-30'}
+Dates in resampled not in raw: {'1983-03-30'}
+File: tasmax_hadukgrid_uk_1km_day_19830501-19830531.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1983-05-30', '1983-05-31'}
+Dates in resampled not in raw: {'1983-04-29', '1983-04-30'}
+File: tasmax_hadukgrid_uk_1km_day_19830601-19830630.nc produced errors:
+raw # days: 30 - resampled # days: 30
+Dates in raw not in resampled: {'1983-06-30'}
+Dates in resampled not in raw: {'1983-05-30'}
+File: tasmax_hadukgrid_uk_1km_day_19830701-19830731.nc produced errors:
+raw # days: 31 - resampled # days: 30
+Dates in raw not in resampled: {'1983-07-31', '1983-07-30'}
+Dates in resampled not in raw: {'1983-06-30'}
+File: tasmax_hadukgrid_uk_1km_day_19830801-19830831.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1983-08-31'}
+Dates in resampled not in raw: {'1983-07-30'}
+File: tasmax_hadukgrid_uk_1km_day_19830901-19830930.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'1983-09-30'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_19831001-19831031.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1983-10-31'}
+Dates in resampled not in raw: {'1983-09-30'}
+File: tasmax_hadukgrid_uk_1km_day_19831101-19831130.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'1983-11-30'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_19831201-19831231.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1983-12-31'}
+Dates in resampled not in raw: {'1983-11-30'}
+File: tasmax_hadukgrid_uk_1km_day_19840101-19840131.nc produced errors:
+raw # days: 31 - resampled # days: 30
+Dates in raw not in resampled: {'1984-01-31'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_19840301-19840331.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1984-03-31'}
+Dates in resampled not in raw: {'1984-02-30'}
+File: tasmax_hadukgrid_uk_1km_day_19840401-19840430.nc produced errors:
+raw # days: 30 - resampled # days: 30
+Dates in raw not in resampled: {'1984-04-30'}
+Dates in resampled not in raw: {'1984-03-30'}
+File: tasmax_hadukgrid_uk_1km_day_19840501-19840531.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1984-05-31'}
+Dates in resampled not in raw: {'1984-04-30'}
+File: tasmax_hadukgrid_uk_1km_day_19840601-19840630.nc produced errors:
+raw # days: 30 - resampled # days: 30
+Dates in raw not in resampled: {'1984-06-30'}
+Dates in resampled not in raw: {'1984-05-30'}
+File: tasmax_hadukgrid_uk_1km_day_19840701-19840731.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1984-07-31'}
+Dates in resampled not in raw: {'1984-06-30'}
+File: tasmax_hadukgrid_uk_1km_day_19840801-19840831.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1984-08-31'}
+Dates in resampled not in raw: {'1984-07-30'}
+File: tasmax_hadukgrid_uk_1km_day_19841001-19841031.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1984-10-31'}
+Dates in resampled not in raw: {'1984-09-30'}
+File: tasmax_hadukgrid_uk_1km_day_19841201-19841231.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1984-12-31'}
+Dates in resampled not in raw: {'1984-11-30'}
+File: tasmax_hadukgrid_uk_1km_day_19850101-19850131.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1985-01-31'}
+Dates in resampled not in raw: {'1985-02-01'}
+File: tasmax_hadukgrid_uk_1km_day_19850201-19850228.nc produced errors:
+raw # days: 28 - resampled # days: 27
+Dates in raw not in resampled: {'1985-02-01'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_19850301-19850331.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1985-03-30', '1985-03-31'}
+Dates in resampled not in raw: {'1985-02-30', '1985-02-29'}
+File: tasmax_hadukgrid_uk_1km_day_19850401-19850430.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'1985-04-30', '1985-04-29'}
+Dates in resampled not in raw: {'1985-03-30'}
+File: tasmax_hadukgrid_uk_1km_day_19850501-19850531.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1985-05-30', '1985-05-31'}
+Dates in resampled not in raw: {'1985-04-30', '1985-04-29'}
+File: tasmax_hadukgrid_uk_1km_day_19850601-19850630.nc produced errors:
+raw # days: 30 - resampled # days: 30
+Dates in raw not in resampled: {'1985-06-30'}
+Dates in resampled not in raw: {'1985-05-30'}
+File: tasmax_hadukgrid_uk_1km_day_19850701-19850731.nc produced errors:
+raw # days: 31 - resampled # days: 30
+Dates in raw not in resampled: {'1985-07-30', '1985-07-31'}
+Dates in resampled not in raw: {'1985-06-30'}
+File: tasmax_hadukgrid_uk_1km_day_19850801-19850831.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1985-08-31'}
+Dates in resampled not in raw: {'1985-07-30'}
+File: tasmax_hadukgrid_uk_1km_day_19850901-19850930.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'1985-09-30'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_19851001-19851031.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1985-10-31'}
+Dates in resampled not in raw: {'1985-09-30'}
+File: tasmax_hadukgrid_uk_1km_day_19851101-19851130.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'1985-11-30'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_19851201-19851231.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1985-12-31'}
+Dates in resampled not in raw: {'1985-11-30'}
+File: tasmax_hadukgrid_uk_1km_day_19860101-19860131.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1986-01-31'}
+Dates in resampled not in raw: {'1986-02-01'}
+File: tasmax_hadukgrid_uk_1km_day_19860201-19860228.nc produced errors:
+raw # days: 28 - resampled # days: 27
+Dates in raw not in resampled: {'1986-02-01'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_19860301-19860331.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1986-03-30', '1986-03-31'}
+Dates in resampled not in raw: {'1986-02-30', '1986-02-29'}
+File: tasmax_hadukgrid_uk_1km_day_19860401-19860430.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'1986-04-29', '1986-04-30'}
+Dates in resampled not in raw: {'1986-03-30'}
+File: tasmax_hadukgrid_uk_1km_day_19860501-19860531.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1986-05-30', '1986-05-31'}
+Dates in resampled not in raw: {'1986-04-29', '1986-04-30'}
+File: tasmax_hadukgrid_uk_1km_day_19860601-19860630.nc produced errors:
+raw # days: 30 - resampled # days: 30
+Dates in raw not in resampled: {'1986-06-30'}
+Dates in resampled not in raw: {'1986-05-30'}
+File: tasmax_hadukgrid_uk_1km_day_19860701-19860731.nc produced errors:
+raw # days: 31 - resampled # days: 30
+Dates in raw not in resampled: {'1986-07-31', '1986-07-30'}
+Dates in resampled not in raw: {'1986-06-30'}
+File: tasmax_hadukgrid_uk_1km_day_19860801-19860831.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1986-08-31'}
+Dates in resampled not in raw: {'1986-07-30'}
+File: tasmax_hadukgrid_uk_1km_day_19860901-19860930.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'1986-09-30'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_19861001-19861031.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1986-10-31'}
+Dates in resampled not in raw: {'1986-09-30'}
+File: tasmax_hadukgrid_uk_1km_day_19861101-19861130.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'1986-11-30'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_19861201-19861231.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1986-12-31'}
+Dates in resampled not in raw: {'1986-11-30'}
+File: tasmax_hadukgrid_uk_1km_day_19870101-19870131.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1987-01-31'}
+Dates in resampled not in raw: {'1987-02-01'}
+File: tasmax_hadukgrid_uk_1km_day_19870201-19870228.nc produced errors:
+raw # days: 28 - resampled # days: 27
+Dates in raw not in resampled: {'1987-02-01'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_19870301-19870331.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1987-03-31', '1987-03-30'}
+Dates in resampled not in raw: {'1987-02-29', '1987-02-30'}
+File: tasmax_hadukgrid_uk_1km_day_19870401-19870430.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'1987-04-29', '1987-04-30'}
+Dates in resampled not in raw: {'1987-03-30'}
+File: tasmax_hadukgrid_uk_1km_day_19870501-19870531.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1987-05-30', '1987-05-31'}
+Dates in resampled not in raw: {'1987-04-29', '1987-04-30'}
+File: tasmax_hadukgrid_uk_1km_day_19870601-19870630.nc produced errors:
+raw # days: 30 - resampled # days: 30
+Dates in raw not in resampled: {'1987-06-30'}
+Dates in resampled not in raw: {'1987-05-30'}
+File: tasmax_hadukgrid_uk_1km_day_19870701-19870731.nc produced errors:
+raw # days: 31 - resampled # days: 30
+Dates in raw not in resampled: {'1987-07-30', '1987-07-31'}
+Dates in resampled not in raw: {'1987-06-30'}
+File: tasmax_hadukgrid_uk_1km_day_19870801-19870831.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1987-08-31'}
+Dates in resampled not in raw: {'1987-07-30'}
+File: tasmax_hadukgrid_uk_1km_day_19870901-19870930.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'1987-09-30'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_19871001-19871031.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1987-10-31'}
+Dates in resampled not in raw: {'1987-09-30'}
+File: tasmax_hadukgrid_uk_1km_day_19871101-19871130.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'1987-11-30'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_19871201-19871231.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1987-12-31'}
+Dates in resampled not in raw: {'1987-11-30'}
+File: tasmax_hadukgrid_uk_1km_day_19880101-19880131.nc produced errors:
+raw # days: 31 - resampled # days: 30
+Dates in raw not in resampled: {'1988-01-31'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_19880301-19880331.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1988-03-31'}
+Dates in resampled not in raw: {'1988-02-30'}
+File: tasmax_hadukgrid_uk_1km_day_19880401-19880430.nc produced errors:
+raw # days: 30 - resampled # days: 30
+Dates in raw not in resampled: {'1988-04-30'}
+Dates in resampled not in raw: {'1988-03-30'}
+File: tasmax_hadukgrid_uk_1km_day_19880501-19880531.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1988-05-31'}
+Dates in resampled not in raw: {'1988-04-30'}
+File: tasmax_hadukgrid_uk_1km_day_19880601-19880630.nc produced errors:
+raw # days: 30 - resampled # days: 30
+Dates in raw not in resampled: {'1988-06-30'}
+Dates in resampled not in raw: {'1988-05-30'}
+File: tasmax_hadukgrid_uk_1km_day_19880701-19880731.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1988-07-31'}
+Dates in resampled not in raw: {'1988-06-30'}
+File: tasmax_hadukgrid_uk_1km_day_19880801-19880831.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1988-08-31'}
+Dates in resampled not in raw: {'1988-07-30'}
+File: tasmax_hadukgrid_uk_1km_day_19881001-19881031.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1988-10-31'}
+Dates in resampled not in raw: {'1988-09-30'}
+File: tasmax_hadukgrid_uk_1km_day_19881201-19881231.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1988-12-31'}
+Dates in resampled not in raw: {'1988-11-30'}
+File: tasmax_hadukgrid_uk_1km_day_19890101-19890131.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1989-01-31'}
+Dates in resampled not in raw: {'1989-02-01'}
+File: tasmax_hadukgrid_uk_1km_day_19890201-19890228.nc produced errors:
+raw # days: 28 - resampled # days: 27
+Dates in raw not in resampled: {'1989-02-01'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_19890301-19890331.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1989-03-30', '1989-03-31'}
+Dates in resampled not in raw: {'1989-02-29', '1989-02-30'}
+File: tasmax_hadukgrid_uk_1km_day_19890401-19890430.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'1989-04-29', '1989-04-30'}
+Dates in resampled not in raw: {'1989-03-30'}
+File: tasmax_hadukgrid_uk_1km_day_19890501-19890531.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1989-05-31', '1989-05-30'}
+Dates in resampled not in raw: {'1989-04-29', '1989-04-30'}
+File: tasmax_hadukgrid_uk_1km_day_19890601-19890630.nc produced errors:
+raw # days: 30 - resampled # days: 30
+Dates in raw not in resampled: {'1989-06-30'}
+Dates in resampled not in raw: {'1989-05-30'}
+File: tasmax_hadukgrid_uk_1km_day_19890701-19890731.nc produced errors:
+raw # days: 31 - resampled # days: 30
+Dates in raw not in resampled: {'1989-07-30', '1989-07-31'}
+Dates in resampled not in raw: {'1989-06-30'}
+File: tasmax_hadukgrid_uk_1km_day_19890801-19890831.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1989-08-31'}
+Dates in resampled not in raw: {'1989-07-30'}
+File: tasmax_hadukgrid_uk_1km_day_19890901-19890930.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'1989-09-30'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_19891001-19891031.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1989-10-31'}
+Dates in resampled not in raw: {'1989-09-30'}
+File: tasmax_hadukgrid_uk_1km_day_19891101-19891130.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'1989-11-30'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_19891201-19891231.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1989-12-31'}
+Dates in resampled not in raw: {'1989-11-30'}
+File: tasmax_hadukgrid_uk_1km_day_19900101-19900131.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1990-01-31'}
+Dates in resampled not in raw: {'1990-02-01'}
+File: tasmax_hadukgrid_uk_1km_day_19900201-19900228.nc produced errors:
+raw # days: 28 - resampled # days: 27
+Dates in raw not in resampled: {'1990-02-01'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_19900301-19900331.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1990-03-30', '1990-03-31'}
+Dates in resampled not in raw: {'1990-02-29', '1990-02-30'}
+File: tasmax_hadukgrid_uk_1km_day_19900401-19900430.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'1990-04-30', '1990-04-29'}
+Dates in resampled not in raw: {'1990-03-30'}
+File: tasmax_hadukgrid_uk_1km_day_19900501-19900531.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1990-05-31', '1990-05-30'}
+Dates in resampled not in raw: {'1990-04-30', '1990-04-29'}
+File: tasmax_hadukgrid_uk_1km_day_19900601-19900630.nc produced errors:
+raw # days: 30 - resampled # days: 30
+Dates in raw not in resampled: {'1990-06-30'}
+Dates in resampled not in raw: {'1990-05-30'}
+File: tasmax_hadukgrid_uk_1km_day_19900701-19900731.nc produced errors:
+raw # days: 31 - resampled # days: 30
+Dates in raw not in resampled: {'1990-07-31', '1990-07-30'}
+Dates in resampled not in raw: {'1990-06-30'}
+File: tasmax_hadukgrid_uk_1km_day_19900801-19900831.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1990-08-31'}
+Dates in resampled not in raw: {'1990-07-30'}
+File: tasmax_hadukgrid_uk_1km_day_19900901-19900930.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'1990-09-30'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_19901001-19901031.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1990-10-31'}
+Dates in resampled not in raw: {'1990-09-30'}
+File: tasmax_hadukgrid_uk_1km_day_19901101-19901130.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'1990-11-30'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_19901201-19901231.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1990-12-31'}
+Dates in resampled not in raw: {'1990-11-30'}
+File: tasmax_hadukgrid_uk_1km_day_19910101-19910131.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1991-01-31'}
+Dates in resampled not in raw: {'1991-02-01'}
+File: tasmax_hadukgrid_uk_1km_day_19910201-19910228.nc produced errors:
+raw # days: 28 - resampled # days: 27
+Dates in raw not in resampled: {'1991-02-01'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_19910301-19910331.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1991-03-30', '1991-03-31'}
+Dates in resampled not in raw: {'1991-02-29', '1991-02-30'}
+File: tasmax_hadukgrid_uk_1km_day_19910401-19910430.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'1991-04-30', '1991-04-29'}
+Dates in resampled not in raw: {'1991-03-30'}
+File: tasmax_hadukgrid_uk_1km_day_19910501-19910531.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1991-05-30', '1991-05-31'}
+Dates in resampled not in raw: {'1991-04-30', '1991-04-29'}
+File: tasmax_hadukgrid_uk_1km_day_19910601-19910630.nc produced errors:
+raw # days: 30 - resampled # days: 30
+Dates in raw not in resampled: {'1991-06-30'}
+Dates in resampled not in raw: {'1991-05-30'}
+File: tasmax_hadukgrid_uk_1km_day_19910701-19910731.nc produced errors:
+raw # days: 31 - resampled # days: 30
+Dates in raw not in resampled: {'1991-07-30', '1991-07-31'}
+Dates in resampled not in raw: {'1991-06-30'}
+File: tasmax_hadukgrid_uk_1km_day_19910801-19910831.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1991-08-31'}
+Dates in resampled not in raw: {'1991-07-30'}
+File: tasmax_hadukgrid_uk_1km_day_19910901-19910930.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'1991-09-30'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_19911001-19911031.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1991-10-31'}
+Dates in resampled not in raw: {'1991-09-30'}
+File: tasmax_hadukgrid_uk_1km_day_19911101-19911130.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'1991-11-30'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_19911201-19911231.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1991-12-31'}
+Dates in resampled not in raw: {'1991-11-30'}
+File: tasmax_hadukgrid_uk_1km_day_19920101-19920131.nc produced errors:
+raw # days: 31 - resampled # days: 30
+Dates in raw not in resampled: {'1992-01-31'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_19920301-19920331.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1992-03-31'}
+Dates in resampled not in raw: {'1992-02-30'}
+File: tasmax_hadukgrid_uk_1km_day_19920401-19920430.nc produced errors:
+raw # days: 30 - resampled # days: 30
+Dates in raw not in resampled: {'1992-04-30'}
+Dates in resampled not in raw: {'1992-03-30'}
+File: tasmax_hadukgrid_uk_1km_day_19920501-19920531.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1992-05-31'}
+Dates in resampled not in raw: {'1992-04-30'}
+File: tasmax_hadukgrid_uk_1km_day_19920601-19920630.nc produced errors:
+raw # days: 30 - resampled # days: 30
+Dates in raw not in resampled: {'1992-06-30'}
+Dates in resampled not in raw: {'1992-05-30'}
+File: tasmax_hadukgrid_uk_1km_day_19920701-19920731.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1992-07-31'}
+Dates in resampled not in raw: {'1992-06-30'}
+File: tasmax_hadukgrid_uk_1km_day_19920801-19920831.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1992-08-31'}
+Dates in resampled not in raw: {'1992-07-30'}
+File: tasmax_hadukgrid_uk_1km_day_19921001-19921031.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1992-10-31'}
+Dates in resampled not in raw: {'1992-09-30'}
+File: tasmax_hadukgrid_uk_1km_day_19921201-19921231.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1992-12-31'}
+Dates in resampled not in raw: {'1992-11-30'}
+File: tasmax_hadukgrid_uk_1km_day_19930101-19930131.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1993-01-31'}
+Dates in resampled not in raw: {'1993-02-01'}
+File: tasmax_hadukgrid_uk_1km_day_19930201-19930228.nc produced errors:
+raw # days: 28 - resampled # days: 27
+Dates in raw not in resampled: {'1993-02-01'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_19930301-19930331.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1993-03-31', '1993-03-30'}
+Dates in resampled not in raw: {'1993-02-30', '1993-02-29'}
+File: tasmax_hadukgrid_uk_1km_day_19930401-19930430.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'1993-04-30', '1993-04-29'}
+Dates in resampled not in raw: {'1993-03-30'}
+File: tasmax_hadukgrid_uk_1km_day_19930501-19930531.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1993-05-31', '1993-05-30'}
+Dates in resampled not in raw: {'1993-04-30', '1993-04-29'}
+File: tasmax_hadukgrid_uk_1km_day_19930601-19930630.nc produced errors:
+raw # days: 30 - resampled # days: 30
+Dates in raw not in resampled: {'1993-06-30'}
+Dates in resampled not in raw: {'1993-05-30'}
+File: tasmax_hadukgrid_uk_1km_day_19930701-19930731.nc produced errors:
+raw # days: 31 - resampled # days: 30
+Dates in raw not in resampled: {'1993-07-31', '1993-07-30'}
+Dates in resampled not in raw: {'1993-06-30'}
+File: tasmax_hadukgrid_uk_1km_day_19930801-19930831.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1993-08-31'}
+Dates in resampled not in raw: {'1993-07-30'}
+File: tasmax_hadukgrid_uk_1km_day_19930901-19930930.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'1993-09-30'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_19931001-19931031.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1993-10-31'}
+Dates in resampled not in raw: {'1993-09-30'}
+File: tasmax_hadukgrid_uk_1km_day_19931101-19931130.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'1993-11-30'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_19931201-19931231.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1993-12-31'}
+Dates in resampled not in raw: {'1993-11-30'}
+File: tasmax_hadukgrid_uk_1km_day_19940101-19940131.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1994-01-31'}
+Dates in resampled not in raw: {'1994-02-01'}
+File: tasmax_hadukgrid_uk_1km_day_19940201-19940228.nc produced errors:
+raw # days: 28 - resampled # days: 27
+Dates in raw not in resampled: {'1994-02-01'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_19940301-19940331.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1994-03-31', '1994-03-30'}
+Dates in resampled not in raw: {'1994-02-30', '1994-02-29'}
+File: tasmax_hadukgrid_uk_1km_day_19940401-19940430.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'1994-04-30', '1994-04-29'}
+Dates in resampled not in raw: {'1994-03-30'}
+File: tasmax_hadukgrid_uk_1km_day_19940501-19940531.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1994-05-31', '1994-05-30'}
+Dates in resampled not in raw: {'1994-04-30', '1994-04-29'}
+File: tasmax_hadukgrid_uk_1km_day_19940601-19940630.nc produced errors:
+raw # days: 30 - resampled # days: 30
+Dates in raw not in resampled: {'1994-06-30'}
+Dates in resampled not in raw: {'1994-05-30'}
+File: tasmax_hadukgrid_uk_1km_day_19940701-19940731.nc produced errors:
+raw # days: 31 - resampled # days: 30
+Dates in raw not in resampled: {'1994-07-31', '1994-07-30'}
+Dates in resampled not in raw: {'1994-06-30'}
+File: tasmax_hadukgrid_uk_1km_day_19940801-19940831.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1994-08-31'}
+Dates in resampled not in raw: {'1994-07-30'}
+File: tasmax_hadukgrid_uk_1km_day_19940901-19940930.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'1994-09-30'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_19941001-19941031.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1994-10-31'}
+Dates in resampled not in raw: {'1994-09-30'}
+File: tasmax_hadukgrid_uk_1km_day_19941101-19941130.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'1994-11-30'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_19941201-19941231.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1994-12-31'}
+Dates in resampled not in raw: {'1994-11-30'}
+File: tasmax_hadukgrid_uk_1km_day_19950101-19950131.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1995-01-31'}
+Dates in resampled not in raw: {'1995-02-01'}
+File: tasmax_hadukgrid_uk_1km_day_19950201-19950228.nc produced errors:
+raw # days: 28 - resampled # days: 27
+Dates in raw not in resampled: {'1995-02-01'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_19950301-19950331.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1995-03-31', '1995-03-30'}
+Dates in resampled not in raw: {'1995-02-29', '1995-02-30'}
+File: tasmax_hadukgrid_uk_1km_day_19950401-19950430.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'1995-04-30', '1995-04-29'}
+Dates in resampled not in raw: {'1995-03-30'}
+File: tasmax_hadukgrid_uk_1km_day_19950501-19950531.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1995-05-30', '1995-05-31'}
+Dates in resampled not in raw: {'1995-04-30', '1995-04-29'}
+File: tasmax_hadukgrid_uk_1km_day_19950601-19950630.nc produced errors:
+raw # days: 30 - resampled # days: 30
+Dates in raw not in resampled: {'1995-06-30'}
+Dates in resampled not in raw: {'1995-05-30'}
+File: tasmax_hadukgrid_uk_1km_day_19950701-19950731.nc produced errors:
+raw # days: 31 - resampled # days: 30
+Dates in raw not in resampled: {'1995-07-30', '1995-07-31'}
+Dates in resampled not in raw: {'1995-06-30'}
+File: tasmax_hadukgrid_uk_1km_day_19950801-19950831.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1995-08-31'}
+Dates in resampled not in raw: {'1995-07-30'}
+File: tasmax_hadukgrid_uk_1km_day_19950901-19950930.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'1995-09-30'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_19951001-19951031.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1995-10-31'}
+Dates in resampled not in raw: {'1995-09-30'}
+File: tasmax_hadukgrid_uk_1km_day_19951101-19951130.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'1995-11-30'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_19951201-19951231.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1995-12-31'}
+Dates in resampled not in raw: {'1995-11-30'}
+File: tasmax_hadukgrid_uk_1km_day_19960101-19960131.nc produced errors:
+raw # days: 31 - resampled # days: 30
+Dates in raw not in resampled: {'1996-01-31'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_19960301-19960331.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1996-03-31'}
+Dates in resampled not in raw: {'1996-02-30'}
+File: tasmax_hadukgrid_uk_1km_day_19960401-19960430.nc produced errors:
+raw # days: 30 - resampled # days: 30
+Dates in raw not in resampled: {'1996-04-30'}
+Dates in resampled not in raw: {'1996-03-30'}
+File: tasmax_hadukgrid_uk_1km_day_19960501-19960531.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1996-05-31'}
+Dates in resampled not in raw: {'1996-04-30'}
+File: tasmax_hadukgrid_uk_1km_day_19960601-19960630.nc produced errors:
+raw # days: 30 - resampled # days: 30
+Dates in raw not in resampled: {'1996-06-30'}
+Dates in resampled not in raw: {'1996-05-30'}
+File: tasmax_hadukgrid_uk_1km_day_19960701-19960731.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1996-07-31'}
+Dates in resampled not in raw: {'1996-06-30'}
+File: tasmax_hadukgrid_uk_1km_day_19960801-19960831.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1996-08-31'}
+Dates in resampled not in raw: {'1996-07-30'}
+File: tasmax_hadukgrid_uk_1km_day_19961001-19961031.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1996-10-31'}
+Dates in resampled not in raw: {'1996-09-30'}
+File: tasmax_hadukgrid_uk_1km_day_19961201-19961231.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1996-12-31'}
+Dates in resampled not in raw: {'1996-11-30'}
+File: tasmax_hadukgrid_uk_1km_day_19970101-19970131.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1997-01-31'}
+Dates in resampled not in raw: {'1997-02-01'}
+File: tasmax_hadukgrid_uk_1km_day_19970201-19970228.nc produced errors:
+raw # days: 28 - resampled # days: 27
+Dates in raw not in resampled: {'1997-02-01'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_19970301-19970331.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1997-03-30', '1997-03-31'}
+Dates in resampled not in raw: {'1997-02-29', '1997-02-30'}
+File: tasmax_hadukgrid_uk_1km_day_19970401-19970430.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'1997-04-29', '1997-04-30'}
+Dates in resampled not in raw: {'1997-03-30'}
+File: tasmax_hadukgrid_uk_1km_day_19970501-19970531.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1997-05-31', '1997-05-30'}
+Dates in resampled not in raw: {'1997-04-29', '1997-04-30'}
+File: tasmax_hadukgrid_uk_1km_day_19970601-19970630.nc produced errors:
+raw # days: 30 - resampled # days: 30
+Dates in raw not in resampled: {'1997-06-30'}
+Dates in resampled not in raw: {'1997-05-30'}
+File: tasmax_hadukgrid_uk_1km_day_19970701-19970731.nc produced errors:
+raw # days: 31 - resampled # days: 30
+Dates in raw not in resampled: {'1997-07-30', '1997-07-31'}
+Dates in resampled not in raw: {'1997-06-30'}
+File: tasmax_hadukgrid_uk_1km_day_19970801-19970831.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1997-08-31'}
+Dates in resampled not in raw: {'1997-07-30'}
+File: tasmax_hadukgrid_uk_1km_day_19970901-19970930.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'1997-09-30'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_19971001-19971031.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1997-10-31'}
+Dates in resampled not in raw: {'1997-09-30'}
+File: tasmax_hadukgrid_uk_1km_day_19971101-19971130.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'1997-11-30'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_19971201-19971231.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1997-12-31'}
+Dates in resampled not in raw: {'1997-11-30'}
+File: tasmax_hadukgrid_uk_1km_day_19980101-19980131.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1998-01-31'}
+Dates in resampled not in raw: {'1998-02-01'}
+File: tasmax_hadukgrid_uk_1km_day_19980201-19980228.nc produced errors:
+raw # days: 28 - resampled # days: 27
+Dates in raw not in resampled: {'1998-02-01'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_19980301-19980331.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1998-03-31', '1998-03-30'}
+Dates in resampled not in raw: {'1998-02-30', '1998-02-29'}
+File: tasmax_hadukgrid_uk_1km_day_19980401-19980430.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'1998-04-30', '1998-04-29'}
+Dates in resampled not in raw: {'1998-03-30'}
+File: tasmax_hadukgrid_uk_1km_day_19980501-19980531.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1998-05-30', '1998-05-31'}
+Dates in resampled not in raw: {'1998-04-30', '1998-04-29'}
+File: tasmax_hadukgrid_uk_1km_day_19980601-19980630.nc produced errors:
+raw # days: 30 - resampled # days: 30
+Dates in raw not in resampled: {'1998-06-30'}
+Dates in resampled not in raw: {'1998-05-30'}
+File: tasmax_hadukgrid_uk_1km_day_19980701-19980731.nc produced errors:
+raw # days: 31 - resampled # days: 30
+Dates in raw not in resampled: {'1998-07-30', '1998-07-31'}
+Dates in resampled not in raw: {'1998-06-30'}
+File: tasmax_hadukgrid_uk_1km_day_19980801-19980831.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1998-08-31'}
+Dates in resampled not in raw: {'1998-07-30'}
+File: tasmax_hadukgrid_uk_1km_day_19980901-19980930.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'1998-09-30'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_19981001-19981031.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1998-10-31'}
+Dates in resampled not in raw: {'1998-09-30'}
+File: tasmax_hadukgrid_uk_1km_day_19981101-19981130.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'1998-11-30'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_19981201-19981231.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1998-12-31'}
+Dates in resampled not in raw: {'1998-11-30'}
+File: tasmax_hadukgrid_uk_1km_day_19990101-19990131.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1999-01-31'}
+Dates in resampled not in raw: {'1999-02-01'}
+File: tasmax_hadukgrid_uk_1km_day_19990201-19990228.nc produced errors:
+raw # days: 28 - resampled # days: 27
+Dates in raw not in resampled: {'1999-02-01'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_19990301-19990331.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1999-03-30', '1999-03-31'}
+Dates in resampled not in raw: {'1999-02-30', '1999-02-29'}
+File: tasmax_hadukgrid_uk_1km_day_19990401-19990430.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'1999-04-30', '1999-04-29'}
+Dates in resampled not in raw: {'1999-03-30'}
+File: tasmax_hadukgrid_uk_1km_day_19990501-19990531.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1999-05-31', '1999-05-30'}
+Dates in resampled not in raw: {'1999-04-30', '1999-04-29'}
+File: tasmax_hadukgrid_uk_1km_day_19990601-19990630.nc produced errors:
+raw # days: 30 - resampled # days: 30
+Dates in raw not in resampled: {'1999-06-30'}
+Dates in resampled not in raw: {'1999-05-30'}
+File: tasmax_hadukgrid_uk_1km_day_19990701-19990731.nc produced errors:
+raw # days: 31 - resampled # days: 30
+Dates in raw not in resampled: {'1999-07-30', '1999-07-31'}
+Dates in resampled not in raw: {'1999-06-30'}
+File: tasmax_hadukgrid_uk_1km_day_19990801-19990831.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1999-08-31'}
+Dates in resampled not in raw: {'1999-07-30'}
+File: tasmax_hadukgrid_uk_1km_day_19990901-19990930.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'1999-09-30'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_19991001-19991031.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1999-10-31'}
+Dates in resampled not in raw: {'1999-09-30'}
+File: tasmax_hadukgrid_uk_1km_day_19991101-19991130.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'1999-11-30'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_19991201-19991231.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'1999-12-31'}
+Dates in resampled not in raw: {'1999-11-30'}
+File: tasmax_hadukgrid_uk_1km_day_20000101-20000131.nc produced errors:
+raw # days: 31 - resampled # days: 30
+Dates in raw not in resampled: {'2000-01-31'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_20000301-20000331.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2000-03-31'}
+Dates in resampled not in raw: {'2000-02-30'}
+File: tasmax_hadukgrid_uk_1km_day_20000401-20000430.nc produced errors:
+raw # days: 30 - resampled # days: 30
+Dates in raw not in resampled: {'2000-04-30'}
+Dates in resampled not in raw: {'2000-03-30'}
+File: tasmax_hadukgrid_uk_1km_day_20000501-20000531.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2000-05-31'}
+Dates in resampled not in raw: {'2000-04-30'}
+File: tasmax_hadukgrid_uk_1km_day_20000601-20000630.nc produced errors:
+raw # days: 30 - resampled # days: 30
+Dates in raw not in resampled: {'2000-06-30'}
+Dates in resampled not in raw: {'2000-05-30'}
+File: tasmax_hadukgrid_uk_1km_day_20000701-20000731.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2000-07-31'}
+Dates in resampled not in raw: {'2000-06-30'}
+File: tasmax_hadukgrid_uk_1km_day_20000801-20000831.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2000-08-31'}
+Dates in resampled not in raw: {'2000-07-30'}
+File: tasmax_hadukgrid_uk_1km_day_20001001-20001031.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2000-10-31'}
+Dates in resampled not in raw: {'2000-09-30'}
+File: tasmax_hadukgrid_uk_1km_day_20001201-20001231.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2000-12-31'}
+Dates in resampled not in raw: {'2000-11-30'}
+File: tasmax_hadukgrid_uk_1km_day_20010101-20010131.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2001-01-31'}
+Dates in resampled not in raw: {'2001-02-01'}
+File: tasmax_hadukgrid_uk_1km_day_20010201-20010228.nc produced errors:
+raw # days: 28 - resampled # days: 27
+Dates in raw not in resampled: {'2001-02-01'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_20010301-20010331.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2001-03-31', '2001-03-30'}
+Dates in resampled not in raw: {'2001-02-30', '2001-02-29'}
+File: tasmax_hadukgrid_uk_1km_day_20010401-20010430.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'2001-04-29', '2001-04-30'}
+Dates in resampled not in raw: {'2001-03-30'}
+File: tasmax_hadukgrid_uk_1km_day_20010501-20010531.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2001-05-31', '2001-05-30'}
+Dates in resampled not in raw: {'2001-04-29', '2001-04-30'}
+File: tasmax_hadukgrid_uk_1km_day_20010601-20010630.nc produced errors:
+raw # days: 30 - resampled # days: 30
+Dates in raw not in resampled: {'2001-06-30'}
+Dates in resampled not in raw: {'2001-05-30'}
+File: tasmax_hadukgrid_uk_1km_day_20010701-20010731.nc produced errors:
+raw # days: 31 - resampled # days: 30
+Dates in raw not in resampled: {'2001-07-30', '2001-07-31'}
+Dates in resampled not in raw: {'2001-06-30'}
+File: tasmax_hadukgrid_uk_1km_day_20010801-20010831.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2001-08-31'}
+Dates in resampled not in raw: {'2001-07-30'}
+File: tasmax_hadukgrid_uk_1km_day_20010901-20010930.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'2001-09-30'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_20011001-20011031.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2001-10-31'}
+Dates in resampled not in raw: {'2001-09-30'}
+File: tasmax_hadukgrid_uk_1km_day_20011101-20011130.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'2001-11-30'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_20011201-20011231.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2001-12-31'}
+Dates in resampled not in raw: {'2001-11-30'}
+File: tasmax_hadukgrid_uk_1km_day_20020101-20020131.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2002-01-31'}
+Dates in resampled not in raw: {'2002-02-01'}
+File: tasmax_hadukgrid_uk_1km_day_20020201-20020228.nc produced errors:
+raw # days: 28 - resampled # days: 27
+Dates in raw not in resampled: {'2002-02-01'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_20020301-20020331.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2002-03-31', '2002-03-30'}
+Dates in resampled not in raw: {'2002-02-30', '2002-02-29'}
+File: tasmax_hadukgrid_uk_1km_day_20020401-20020430.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'2002-04-29', '2002-04-30'}
+Dates in resampled not in raw: {'2002-03-30'}
+File: tasmax_hadukgrid_uk_1km_day_20020501-20020531.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2002-05-31', '2002-05-30'}
+Dates in resampled not in raw: {'2002-04-29', '2002-04-30'}
+File: tasmax_hadukgrid_uk_1km_day_20020601-20020630.nc produced errors:
+raw # days: 30 - resampled # days: 30
+Dates in raw not in resampled: {'2002-06-30'}
+Dates in resampled not in raw: {'2002-05-30'}
+File: tasmax_hadukgrid_uk_1km_day_20020701-20020731.nc produced errors:
+raw # days: 31 - resampled # days: 30
+Dates in raw not in resampled: {'2002-07-30', '2002-07-31'}
+Dates in resampled not in raw: {'2002-06-30'}
+File: tasmax_hadukgrid_uk_1km_day_20020801-20020831.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2002-08-31'}
+Dates in resampled not in raw: {'2002-07-30'}
+File: tasmax_hadukgrid_uk_1km_day_20020901-20020930.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'2002-09-30'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_20021001-20021031.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2002-10-31'}
+Dates in resampled not in raw: {'2002-09-30'}
+File: tasmax_hadukgrid_uk_1km_day_20021101-20021130.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'2002-11-30'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_20021201-20021231.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2002-12-31'}
+Dates in resampled not in raw: {'2002-11-30'}
+File: tasmax_hadukgrid_uk_1km_day_20030101-20030131.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2003-01-31'}
+Dates in resampled not in raw: {'2003-02-01'}
+File: tasmax_hadukgrid_uk_1km_day_20030201-20030228.nc produced errors:
+raw # days: 28 - resampled # days: 27
+Dates in raw not in resampled: {'2003-02-01'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_20030301-20030331.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2003-03-30', '2003-03-31'}
+Dates in resampled not in raw: {'2003-02-29', '2003-02-30'}
+File: tasmax_hadukgrid_uk_1km_day_20030401-20030430.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'2003-04-30', '2003-04-29'}
+Dates in resampled not in raw: {'2003-03-30'}
+File: tasmax_hadukgrid_uk_1km_day_20030501-20030531.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2003-05-31', '2003-05-30'}
+Dates in resampled not in raw: {'2003-04-30', '2003-04-29'}
+File: tasmax_hadukgrid_uk_1km_day_20030601-20030630.nc produced errors:
+raw # days: 30 - resampled # days: 30
+Dates in raw not in resampled: {'2003-06-30'}
+Dates in resampled not in raw: {'2003-05-30'}
+File: tasmax_hadukgrid_uk_1km_day_20030701-20030731.nc produced errors:
+raw # days: 31 - resampled # days: 30
+Dates in raw not in resampled: {'2003-07-30', '2003-07-31'}
+Dates in resampled not in raw: {'2003-06-30'}
+File: tasmax_hadukgrid_uk_1km_day_20030801-20030831.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2003-08-31'}
+Dates in resampled not in raw: {'2003-07-30'}
+File: tasmax_hadukgrid_uk_1km_day_20030901-20030930.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'2003-09-30'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_20031001-20031031.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2003-10-31'}
+Dates in resampled not in raw: {'2003-09-30'}
+File: tasmax_hadukgrid_uk_1km_day_20031101-20031130.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'2003-11-30'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_20031201-20031231.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2003-12-31'}
+Dates in resampled not in raw: {'2003-11-30'}
+File: tasmax_hadukgrid_uk_1km_day_20040101-20040131.nc produced errors:
+raw # days: 31 - resampled # days: 30
+Dates in raw not in resampled: {'2004-01-31'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_20040301-20040331.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2004-03-31'}
+Dates in resampled not in raw: {'2004-02-30'}
+File: tasmax_hadukgrid_uk_1km_day_20040401-20040430.nc produced errors:
+raw # days: 30 - resampled # days: 30
+Dates in raw not in resampled: {'2004-04-30'}
+Dates in resampled not in raw: {'2004-03-30'}
+File: tasmax_hadukgrid_uk_1km_day_20040501-20040531.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2004-05-31'}
+Dates in resampled not in raw: {'2004-04-30'}
+File: tasmax_hadukgrid_uk_1km_day_20040601-20040630.nc produced errors:
+raw # days: 30 - resampled # days: 30
+Dates in raw not in resampled: {'2004-06-30'}
+Dates in resampled not in raw: {'2004-05-30'}
+File: tasmax_hadukgrid_uk_1km_day_20040701-20040731.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2004-07-31'}
+Dates in resampled not in raw: {'2004-06-30'}
+File: tasmax_hadukgrid_uk_1km_day_20040801-20040831.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2004-08-31'}
+Dates in resampled not in raw: {'2004-07-30'}
+File: tasmax_hadukgrid_uk_1km_day_20041001-20041031.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2004-10-31'}
+Dates in resampled not in raw: {'2004-09-30'}
+File: tasmax_hadukgrid_uk_1km_day_20041201-20041231.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2004-12-31'}
+Dates in resampled not in raw: {'2004-11-30'}
+File: tasmax_hadukgrid_uk_1km_day_20050101-20050131.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2005-01-31'}
+Dates in resampled not in raw: {'2005-02-01'}
+File: tasmax_hadukgrid_uk_1km_day_20050201-20050228.nc produced errors:
+raw # days: 28 - resampled # days: 27
+Dates in raw not in resampled: {'2005-02-01'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_20050301-20050331.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2005-03-31', '2005-03-30'}
+Dates in resampled not in raw: {'2005-02-29', '2005-02-30'}
+File: tasmax_hadukgrid_uk_1km_day_20050401-20050430.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'2005-04-29', '2005-04-30'}
+Dates in resampled not in raw: {'2005-03-30'}
+File: tasmax_hadukgrid_uk_1km_day_20050501-20050531.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2005-05-31', '2005-05-30'}
+Dates in resampled not in raw: {'2005-04-29', '2005-04-30'}
+File: tasmax_hadukgrid_uk_1km_day_20050601-20050630.nc produced errors:
+raw # days: 30 - resampled # days: 30
+Dates in raw not in resampled: {'2005-06-30'}
+Dates in resampled not in raw: {'2005-05-30'}
+File: tasmax_hadukgrid_uk_1km_day_20050701-20050731.nc produced errors:
+raw # days: 31 - resampled # days: 30
+Dates in raw not in resampled: {'2005-07-31', '2005-07-30'}
+Dates in resampled not in raw: {'2005-06-30'}
+File: tasmax_hadukgrid_uk_1km_day_20050801-20050831.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2005-08-31'}
+Dates in resampled not in raw: {'2005-07-30'}
+File: tasmax_hadukgrid_uk_1km_day_20050901-20050930.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'2005-09-30'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_20051001-20051031.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2005-10-31'}
+Dates in resampled not in raw: {'2005-09-30'}
+File: tasmax_hadukgrid_uk_1km_day_20051101-20051130.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'2005-11-30'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_20051201-20051231.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2005-12-31'}
+Dates in resampled not in raw: {'2005-11-30'}
+File: tasmax_hadukgrid_uk_1km_day_20060101-20060131.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2006-01-31'}
+Dates in resampled not in raw: {'2006-02-01'}
+File: tasmax_hadukgrid_uk_1km_day_20060201-20060228.nc produced errors:
+raw # days: 28 - resampled # days: 27
+Dates in raw not in resampled: {'2006-02-01'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_20060301-20060331.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2006-03-30', '2006-03-31'}
+Dates in resampled not in raw: {'2006-02-29', '2006-02-30'}
+File: tasmax_hadukgrid_uk_1km_day_20060401-20060430.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'2006-04-29', '2006-04-30'}
+Dates in resampled not in raw: {'2006-03-30'}
+File: tasmax_hadukgrid_uk_1km_day_20060501-20060531.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2006-05-31', '2006-05-30'}
+Dates in resampled not in raw: {'2006-04-29', '2006-04-30'}
+File: tasmax_hadukgrid_uk_1km_day_20060601-20060630.nc produced errors:
+raw # days: 30 - resampled # days: 30
+Dates in raw not in resampled: {'2006-06-30'}
+Dates in resampled not in raw: {'2006-05-30'}
+File: tasmax_hadukgrid_uk_1km_day_20060701-20060731.nc produced errors:
+raw # days: 31 - resampled # days: 30
+Dates in raw not in resampled: {'2006-07-31', '2006-07-30'}
+Dates in resampled not in raw: {'2006-06-30'}
+File: tasmax_hadukgrid_uk_1km_day_20060801-20060831.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2006-08-31'}
+Dates in resampled not in raw: {'2006-07-30'}
+File: tasmax_hadukgrid_uk_1km_day_20060901-20060930.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'2006-09-30'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_20061001-20061031.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2006-10-31'}
+Dates in resampled not in raw: {'2006-09-30'}
+File: tasmax_hadukgrid_uk_1km_day_20061101-20061130.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'2006-11-30'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_20061201-20061231.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2006-12-31'}
+Dates in resampled not in raw: {'2006-11-30'}
+File: tasmax_hadukgrid_uk_1km_day_20070101-20070131.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2007-01-31'}
+Dates in resampled not in raw: {'2007-02-01'}
+File: tasmax_hadukgrid_uk_1km_day_20070201-20070228.nc produced errors:
+raw # days: 28 - resampled # days: 27
+Dates in raw not in resampled: {'2007-02-01'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_20070301-20070331.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2007-03-31', '2007-03-30'}
+Dates in resampled not in raw: {'2007-02-29', '2007-02-30'}
+File: tasmax_hadukgrid_uk_1km_day_20070401-20070430.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'2007-04-30', '2007-04-29'}
+Dates in resampled not in raw: {'2007-03-30'}
+File: tasmax_hadukgrid_uk_1km_day_20070501-20070531.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2007-05-31', '2007-05-30'}
+Dates in resampled not in raw: {'2007-04-30', '2007-04-29'}
+File: tasmax_hadukgrid_uk_1km_day_20070601-20070630.nc produced errors:
+raw # days: 30 - resampled # days: 30
+Dates in raw not in resampled: {'2007-06-30'}
+Dates in resampled not in raw: {'2007-05-30'}
+File: tasmax_hadukgrid_uk_1km_day_20070701-20070731.nc produced errors:
+raw # days: 31 - resampled # days: 30
+Dates in raw not in resampled: {'2007-07-31', '2007-07-30'}
+Dates in resampled not in raw: {'2007-06-30'}
+File: tasmax_hadukgrid_uk_1km_day_20070801-20070831.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2007-08-31'}
+Dates in resampled not in raw: {'2007-07-30'}
+File: tasmax_hadukgrid_uk_1km_day_20070901-20070930.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'2007-09-30'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_20071001-20071031.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2007-10-31'}
+Dates in resampled not in raw: {'2007-09-30'}
+File: tasmax_hadukgrid_uk_1km_day_20071101-20071130.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'2007-11-30'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_20071201-20071231.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2007-12-31'}
+Dates in resampled not in raw: {'2007-11-30'}
+File: tasmax_hadukgrid_uk_1km_day_20080101-20080131.nc produced errors:
+raw # days: 31 - resampled # days: 30
+Dates in raw not in resampled: {'2008-01-31'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_20080301-20080331.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2008-03-31'}
+Dates in resampled not in raw: {'2008-02-30'}
+File: tasmax_hadukgrid_uk_1km_day_20080401-20080430.nc produced errors:
+raw # days: 30 - resampled # days: 30
+Dates in raw not in resampled: {'2008-04-30'}
+Dates in resampled not in raw: {'2008-03-30'}
+File: tasmax_hadukgrid_uk_1km_day_20080501-20080531.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2008-05-31'}
+Dates in resampled not in raw: {'2008-04-30'}
+File: tasmax_hadukgrid_uk_1km_day_20080601-20080630.nc produced errors:
+raw # days: 30 - resampled # days: 30
+Dates in raw not in resampled: {'2008-06-30'}
+Dates in resampled not in raw: {'2008-05-30'}
+File: tasmax_hadukgrid_uk_1km_day_20080701-20080731.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2008-07-31'}
+Dates in resampled not in raw: {'2008-06-30'}
+File: tasmax_hadukgrid_uk_1km_day_20080801-20080831.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2008-08-31'}
+Dates in resampled not in raw: {'2008-07-30'}
+File: tasmax_hadukgrid_uk_1km_day_20081001-20081031.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2008-10-31'}
+Dates in resampled not in raw: {'2008-09-30'}
+File: tasmax_hadukgrid_uk_1km_day_20081201-20081231.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2008-12-31'}
+Dates in resampled not in raw: {'2008-11-30'}
+File: tasmax_hadukgrid_uk_1km_day_20090101-20090131.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2009-01-31'}
+Dates in resampled not in raw: {'2009-02-01'}
+File: tasmax_hadukgrid_uk_1km_day_20090201-20090228.nc produced errors:
+raw # days: 28 - resampled # days: 27
+Dates in raw not in resampled: {'2009-02-01'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_20090301-20090331.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2009-03-31', '2009-03-30'}
+Dates in resampled not in raw: {'2009-02-30', '2009-02-29'}
+File: tasmax_hadukgrid_uk_1km_day_20090401-20090430.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'2009-04-30', '2009-04-29'}
+Dates in resampled not in raw: {'2009-03-30'}
+File: tasmax_hadukgrid_uk_1km_day_20090501-20090531.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2009-05-30', '2009-05-31'}
+Dates in resampled not in raw: {'2009-04-30', '2009-04-29'}
+File: tasmax_hadukgrid_uk_1km_day_20090601-20090630.nc produced errors:
+raw # days: 30 - resampled # days: 30
+Dates in raw not in resampled: {'2009-06-30'}
+Dates in resampled not in raw: {'2009-05-30'}
+File: tasmax_hadukgrid_uk_1km_day_20090701-20090731.nc produced errors:
+raw # days: 31 - resampled # days: 30
+Dates in raw not in resampled: {'2009-07-31', '2009-07-30'}
+Dates in resampled not in raw: {'2009-06-30'}
+File: tasmax_hadukgrid_uk_1km_day_20090801-20090831.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2009-08-31'}
+Dates in resampled not in raw: {'2009-07-30'}
+File: tasmax_hadukgrid_uk_1km_day_20090901-20090930.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'2009-09-30'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_20091001-20091031.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2009-10-31'}
+Dates in resampled not in raw: {'2009-09-30'}
+File: tasmax_hadukgrid_uk_1km_day_20091101-20091130.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'2009-11-30'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_20091201-20091231.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2009-12-31'}
+Dates in resampled not in raw: {'2009-11-30'}
+File: tasmax_hadukgrid_uk_1km_day_20100101-20100131.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2010-01-31'}
+Dates in resampled not in raw: {'2010-02-01'}
+File: tasmax_hadukgrid_uk_1km_day_20100201-20100228.nc produced errors:
+raw # days: 28 - resampled # days: 27
+Dates in raw not in resampled: {'2010-02-01'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_20100301-20100331.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2010-03-31', '2010-03-30'}
+Dates in resampled not in raw: {'2010-02-29', '2010-02-30'}
+File: tasmax_hadukgrid_uk_1km_day_20100401-20100430.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'2010-04-29', '2010-04-30'}
+Dates in resampled not in raw: {'2010-03-30'}
+File: tasmax_hadukgrid_uk_1km_day_20100501-20100531.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2010-05-30', '2010-05-31'}
+Dates in resampled not in raw: {'2010-04-29', '2010-04-30'}
+File: tasmax_hadukgrid_uk_1km_day_20100601-20100630.nc produced errors:
+raw # days: 30 - resampled # days: 30
+Dates in raw not in resampled: {'2010-06-30'}
+Dates in resampled not in raw: {'2010-05-30'}
+File: tasmax_hadukgrid_uk_1km_day_20100701-20100731.nc produced errors:
+raw # days: 31 - resampled # days: 30
+Dates in raw not in resampled: {'2010-07-30', '2010-07-31'}
+Dates in resampled not in raw: {'2010-06-30'}
+File: tasmax_hadukgrid_uk_1km_day_20100801-20100831.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2010-08-31'}
+Dates in resampled not in raw: {'2010-07-30'}
+File: tasmax_hadukgrid_uk_1km_day_20100901-20100930.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'2010-09-30'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_20101001-20101031.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2010-10-31'}
+Dates in resampled not in raw: {'2010-09-30'}
+File: tasmax_hadukgrid_uk_1km_day_20101101-20101130.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'2010-11-30'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_20101201-20101231.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2010-12-31'}
+Dates in resampled not in raw: {'2010-11-30'}
+File: tasmax_hadukgrid_uk_1km_day_20110101-20110131.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2011-01-31'}
+Dates in resampled not in raw: {'2011-02-01'}
+File: tasmax_hadukgrid_uk_1km_day_20110201-20110228.nc produced errors:
+raw # days: 28 - resampled # days: 27
+Dates in raw not in resampled: {'2011-02-01'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_20110301-20110331.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2011-03-30', '2011-03-31'}
+Dates in resampled not in raw: {'2011-02-29', '2011-02-30'}
+File: tasmax_hadukgrid_uk_1km_day_20110401-20110430.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'2011-04-30', '2011-04-29'}
+Dates in resampled not in raw: {'2011-03-30'}
+File: tasmax_hadukgrid_uk_1km_day_20110501-20110531.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2011-05-30', '2011-05-31'}
+Dates in resampled not in raw: {'2011-04-30', '2011-04-29'}
+File: tasmax_hadukgrid_uk_1km_day_20110601-20110630.nc produced errors:
+raw # days: 30 - resampled # days: 30
+Dates in raw not in resampled: {'2011-06-30'}
+Dates in resampled not in raw: {'2011-05-30'}
+File: tasmax_hadukgrid_uk_1km_day_20110701-20110731.nc produced errors:
+raw # days: 31 - resampled # days: 30
+Dates in raw not in resampled: {'2011-07-31', '2011-07-30'}
+Dates in resampled not in raw: {'2011-06-30'}
+File: tasmax_hadukgrid_uk_1km_day_20110801-20110831.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2011-08-31'}
+Dates in resampled not in raw: {'2011-07-30'}
+File: tasmax_hadukgrid_uk_1km_day_20110901-20110930.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'2011-09-30'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_20111001-20111031.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2011-10-31'}
+Dates in resampled not in raw: {'2011-09-30'}
+File: tasmax_hadukgrid_uk_1km_day_20111101-20111130.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'2011-11-30'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_20111201-20111231.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2011-12-31'}
+Dates in resampled not in raw: {'2011-11-30'}
+File: tasmax_hadukgrid_uk_1km_day_20120101-20120131.nc produced errors:
+raw # days: 31 - resampled # days: 30
+Dates in raw not in resampled: {'2012-01-31'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_20120301-20120331.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2012-03-31'}
+Dates in resampled not in raw: {'2012-02-30'}
+File: tasmax_hadukgrid_uk_1km_day_20120401-20120430.nc produced errors:
+raw # days: 30 - resampled # days: 30
+Dates in raw not in resampled: {'2012-04-30'}
+Dates in resampled not in raw: {'2012-03-30'}
+File: tasmax_hadukgrid_uk_1km_day_20120501-20120531.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2012-05-31'}
+Dates in resampled not in raw: {'2012-04-30'}
+File: tasmax_hadukgrid_uk_1km_day_20120601-20120630.nc produced errors:
+raw # days: 30 - resampled # days: 30
+Dates in raw not in resampled: {'2012-06-30'}
+Dates in resampled not in raw: {'2012-05-30'}
+File: tasmax_hadukgrid_uk_1km_day_20120701-20120731.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2012-07-31'}
+Dates in resampled not in raw: {'2012-06-30'}
+File: tasmax_hadukgrid_uk_1km_day_20120801-20120831.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2012-08-31'}
+Dates in resampled not in raw: {'2012-07-30'}
+File: tasmax_hadukgrid_uk_1km_day_20121001-20121031.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2012-10-31'}
+Dates in resampled not in raw: {'2012-09-30'}
+File: tasmax_hadukgrid_uk_1km_day_20121201-20121231.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2012-12-31'}
+Dates in resampled not in raw: {'2012-11-30'}
+File: tasmax_hadukgrid_uk_1km_day_20130101-20130131.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2013-01-31'}
+Dates in resampled not in raw: {'2013-02-01'}
+File: tasmax_hadukgrid_uk_1km_day_20130201-20130228.nc produced errors:
+raw # days: 28 - resampled # days: 27
+Dates in raw not in resampled: {'2013-02-01'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_20130301-20130331.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2013-03-30', '2013-03-31'}
+Dates in resampled not in raw: {'2013-02-30', '2013-02-29'}
+File: tasmax_hadukgrid_uk_1km_day_20130401-20130430.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'2013-04-29', '2013-04-30'}
+Dates in resampled not in raw: {'2013-03-30'}
+File: tasmax_hadukgrid_uk_1km_day_20130501-20130531.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2013-05-30', '2013-05-31'}
+Dates in resampled not in raw: {'2013-04-29', '2013-04-30'}
+File: tasmax_hadukgrid_uk_1km_day_20130601-20130630.nc produced errors:
+raw # days: 30 - resampled # days: 30
+Dates in raw not in resampled: {'2013-06-30'}
+Dates in resampled not in raw: {'2013-05-30'}
+File: tasmax_hadukgrid_uk_1km_day_20130701-20130731.nc produced errors:
+raw # days: 31 - resampled # days: 30
+Dates in raw not in resampled: {'2013-07-31', '2013-07-30'}
+Dates in resampled not in raw: {'2013-06-30'}
+File: tasmax_hadukgrid_uk_1km_day_20130801-20130831.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2013-08-31'}
+Dates in resampled not in raw: {'2013-07-30'}
+File: tasmax_hadukgrid_uk_1km_day_20130901-20130930.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'2013-09-30'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_20131001-20131031.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2013-10-31'}
+Dates in resampled not in raw: {'2013-09-30'}
+File: tasmax_hadukgrid_uk_1km_day_20131101-20131130.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'2013-11-30'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_20131201-20131231.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2013-12-31'}
+Dates in resampled not in raw: {'2013-11-30'}
+File: tasmax_hadukgrid_uk_1km_day_20140101-20140131.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2014-01-31'}
+Dates in resampled not in raw: {'2014-02-01'}
+File: tasmax_hadukgrid_uk_1km_day_20140201-20140228.nc produced errors:
+raw # days: 28 - resampled # days: 27
+Dates in raw not in resampled: {'2014-02-01'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_20140301-20140331.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2014-03-31', '2014-03-30'}
+Dates in resampled not in raw: {'2014-02-30', '2014-02-29'}
+File: tasmax_hadukgrid_uk_1km_day_20140401-20140430.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'2014-04-29', '2014-04-30'}
+Dates in resampled not in raw: {'2014-03-30'}
+File: tasmax_hadukgrid_uk_1km_day_20140501-20140531.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2014-05-31', '2014-05-30'}
+Dates in resampled not in raw: {'2014-04-29', '2014-04-30'}
+File: tasmax_hadukgrid_uk_1km_day_20140601-20140630.nc produced errors:
+raw # days: 30 - resampled # days: 30
+Dates in raw not in resampled: {'2014-06-30'}
+Dates in resampled not in raw: {'2014-05-30'}
+File: tasmax_hadukgrid_uk_1km_day_20140701-20140731.nc produced errors:
+raw # days: 31 - resampled # days: 30
+Dates in raw not in resampled: {'2014-07-31', '2014-07-30'}
+Dates in resampled not in raw: {'2014-06-30'}
+File: tasmax_hadukgrid_uk_1km_day_20140801-20140831.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2014-08-31'}
+Dates in resampled not in raw: {'2014-07-30'}
+File: tasmax_hadukgrid_uk_1km_day_20140901-20140930.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'2014-09-30'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_20141001-20141031.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2014-10-31'}
+Dates in resampled not in raw: {'2014-09-30'}
+File: tasmax_hadukgrid_uk_1km_day_20141101-20141130.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'2014-11-30'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_20141201-20141231.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2014-12-31'}
+Dates in resampled not in raw: {'2014-11-30'}
+File: tasmax_hadukgrid_uk_1km_day_20150101-20150131.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2015-01-31'}
+Dates in resampled not in raw: {'2015-02-01'}
+File: tasmax_hadukgrid_uk_1km_day_20150201-20150228.nc produced errors:
+raw # days: 28 - resampled # days: 27
+Dates in raw not in resampled: {'2015-02-01'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_20150301-20150331.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2015-03-31', '2015-03-30'}
+Dates in resampled not in raw: {'2015-02-29', '2015-02-30'}
+File: tasmax_hadukgrid_uk_1km_day_20150401-20150430.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'2015-04-29', '2015-04-30'}
+Dates in resampled not in raw: {'2015-03-30'}
+File: tasmax_hadukgrid_uk_1km_day_20150501-20150531.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2015-05-31', '2015-05-30'}
+Dates in resampled not in raw: {'2015-04-29', '2015-04-30'}
+File: tasmax_hadukgrid_uk_1km_day_20150601-20150630.nc produced errors:
+raw # days: 30 - resampled # days: 30
+Dates in raw not in resampled: {'2015-06-30'}
+Dates in resampled not in raw: {'2015-05-30'}
+File: tasmax_hadukgrid_uk_1km_day_20150701-20150731.nc produced errors:
+raw # days: 31 - resampled # days: 30
+Dates in raw not in resampled: {'2015-07-31', '2015-07-30'}
+Dates in resampled not in raw: {'2015-06-30'}
+File: tasmax_hadukgrid_uk_1km_day_20150801-20150831.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2015-08-31'}
+Dates in resampled not in raw: {'2015-07-30'}
+File: tasmax_hadukgrid_uk_1km_day_20150901-20150930.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'2015-09-30'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_20151001-20151031.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2015-10-31'}
+Dates in resampled not in raw: {'2015-09-30'}
+File: tasmax_hadukgrid_uk_1km_day_20151101-20151130.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'2015-11-30'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_20151201-20151231.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2015-12-31'}
+Dates in resampled not in raw: {'2015-11-30'}
+File: tasmax_hadukgrid_uk_1km_day_20160101-20160131.nc produced errors:
+raw # days: 31 - resampled # days: 30
+Dates in raw not in resampled: {'2016-01-31'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_20160301-20160331.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2016-03-31'}
+Dates in resampled not in raw: {'2016-02-30'}
+File: tasmax_hadukgrid_uk_1km_day_20160401-20160430.nc produced errors:
+raw # days: 30 - resampled # days: 30
+Dates in raw not in resampled: {'2016-04-30'}
+Dates in resampled not in raw: {'2016-03-30'}
+File: tasmax_hadukgrid_uk_1km_day_20160501-20160531.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2016-05-31'}
+Dates in resampled not in raw: {'2016-04-30'}
+File: tasmax_hadukgrid_uk_1km_day_20160601-20160630.nc produced errors:
+raw # days: 30 - resampled # days: 30
+Dates in raw not in resampled: {'2016-06-30'}
+Dates in resampled not in raw: {'2016-05-30'}
+File: tasmax_hadukgrid_uk_1km_day_20160701-20160731.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2016-07-31'}
+Dates in resampled not in raw: {'2016-06-30'}
+File: tasmax_hadukgrid_uk_1km_day_20160801-20160831.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2016-08-31'}
+Dates in resampled not in raw: {'2016-07-30'}
+File: tasmax_hadukgrid_uk_1km_day_20161001-20161031.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2016-10-31'}
+Dates in resampled not in raw: {'2016-09-30'}
+File: tasmax_hadukgrid_uk_1km_day_20161201-20161231.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2016-12-31'}
+Dates in resampled not in raw: {'2016-11-30'}
+File: tasmax_hadukgrid_uk_1km_day_20170101-20170131.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2017-01-31'}
+Dates in resampled not in raw: {'2017-02-01'}
+File: tasmax_hadukgrid_uk_1km_day_20170201-20170228.nc produced errors:
+raw # days: 28 - resampled # days: 27
+Dates in raw not in resampled: {'2017-02-01'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_20170301-20170331.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2017-03-31', '2017-03-30'}
+Dates in resampled not in raw: {'2017-02-29', '2017-02-30'}
+File: tasmax_hadukgrid_uk_1km_day_20170401-20170430.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'2017-04-30', '2017-04-29'}
+Dates in resampled not in raw: {'2017-03-30'}
+File: tasmax_hadukgrid_uk_1km_day_20170501-20170531.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2017-05-31', '2017-05-30'}
+Dates in resampled not in raw: {'2017-04-30', '2017-04-29'}
+File: tasmax_hadukgrid_uk_1km_day_20170601-20170630.nc produced errors:
+raw # days: 30 - resampled # days: 30
+Dates in raw not in resampled: {'2017-06-30'}
+Dates in resampled not in raw: {'2017-05-30'}
+File: tasmax_hadukgrid_uk_1km_day_20170701-20170731.nc produced errors:
+raw # days: 31 - resampled # days: 30
+Dates in raw not in resampled: {'2017-07-30', '2017-07-31'}
+Dates in resampled not in raw: {'2017-06-30'}
+File: tasmax_hadukgrid_uk_1km_day_20170801-20170831.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2017-08-31'}
+Dates in resampled not in raw: {'2017-07-30'}
+File: tasmax_hadukgrid_uk_1km_day_20170901-20170930.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'2017-09-30'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_20171001-20171031.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2017-10-31'}
+Dates in resampled not in raw: {'2017-09-30'}
+File: tasmax_hadukgrid_uk_1km_day_20171101-20171130.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'2017-11-30'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_20171201-20171231.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2017-12-31'}
+Dates in resampled not in raw: {'2017-11-30'}
+File: tasmax_hadukgrid_uk_1km_day_20180101-20180131.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2018-01-31'}
+Dates in resampled not in raw: {'2018-02-01'}
+File: tasmax_hadukgrid_uk_1km_day_20180201-20180228.nc produced errors:
+raw # days: 28 - resampled # days: 27
+Dates in raw not in resampled: {'2018-02-01'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_20180301-20180331.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2018-03-30', '2018-03-31'}
+Dates in resampled not in raw: {'2018-02-30', '2018-02-29'}
+File: tasmax_hadukgrid_uk_1km_day_20180401-20180430.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'2018-04-29', '2018-04-30'}
+Dates in resampled not in raw: {'2018-03-30'}
+File: tasmax_hadukgrid_uk_1km_day_20180501-20180531.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2018-05-30', '2018-05-31'}
+Dates in resampled not in raw: {'2018-04-29', '2018-04-30'}
+File: tasmax_hadukgrid_uk_1km_day_20180601-20180630.nc produced errors:
+raw # days: 30 - resampled # days: 30
+Dates in raw not in resampled: {'2018-06-30'}
+Dates in resampled not in raw: {'2018-05-30'}
+File: tasmax_hadukgrid_uk_1km_day_20180701-20180731.nc produced errors:
+raw # days: 31 - resampled # days: 30
+Dates in raw not in resampled: {'2018-07-31', '2018-07-30'}
+Dates in resampled not in raw: {'2018-06-30'}
+File: tasmax_hadukgrid_uk_1km_day_20180801-20180831.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2018-08-31'}
+Dates in resampled not in raw: {'2018-07-30'}
+File: tasmax_hadukgrid_uk_1km_day_20180901-20180930.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'2018-09-30'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_20181001-20181031.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2018-10-31'}
+Dates in resampled not in raw: {'2018-09-30'}
+File: tasmax_hadukgrid_uk_1km_day_20181101-20181130.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'2018-11-30'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_20181201-20181231.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2018-12-31'}
+Dates in resampled not in raw: {'2018-11-30'}
+File: tasmax_hadukgrid_uk_1km_day_20190101-20190131.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2019-01-31'}
+Dates in resampled not in raw: {'2019-02-01'}
+File: tasmax_hadukgrid_uk_1km_day_20190201-20190228.nc produced errors:
+raw # days: 28 - resampled # days: 27
+Dates in raw not in resampled: {'2019-02-01'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_20190301-20190331.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2019-03-31', '2019-03-30'}
+Dates in resampled not in raw: {'2019-02-29', '2019-02-30'}
+File: tasmax_hadukgrid_uk_1km_day_20190401-20190430.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'2019-04-29', '2019-04-30'}
+Dates in resampled not in raw: {'2019-03-30'}
+File: tasmax_hadukgrid_uk_1km_day_20190501-20190531.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2019-05-31', '2019-05-30'}
+Dates in resampled not in raw: {'2019-04-29', '2019-04-30'}
+File: tasmax_hadukgrid_uk_1km_day_20190601-20190630.nc produced errors:
+raw # days: 30 - resampled # days: 30
+Dates in raw not in resampled: {'2019-06-30'}
+Dates in resampled not in raw: {'2019-05-30'}
+File: tasmax_hadukgrid_uk_1km_day_20190701-20190731.nc produced errors:
+raw # days: 31 - resampled # days: 30
+Dates in raw not in resampled: {'2019-07-30', '2019-07-31'}
+Dates in resampled not in raw: {'2019-06-30'}
+File: tasmax_hadukgrid_uk_1km_day_20190801-20190831.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2019-08-31'}
+Dates in resampled not in raw: {'2019-07-30'}
+File: tasmax_hadukgrid_uk_1km_day_20190901-20190930.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'2019-09-30'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_20191001-20191031.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2019-10-31'}
+Dates in resampled not in raw: {'2019-09-30'}
+File: tasmax_hadukgrid_uk_1km_day_20191101-20191130.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'2019-11-30'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_20191201-20191231.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2019-12-31'}
+Dates in resampled not in raw: {'2019-11-30'}
+File: tasmax_hadukgrid_uk_1km_day_20200101-20200131.nc produced errors:
+raw # days: 31 - resampled # days: 30
+Dates in raw not in resampled: {'2020-01-31'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_20200301-20200331.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2020-03-31'}
+Dates in resampled not in raw: {'2020-02-30'}
+File: tasmax_hadukgrid_uk_1km_day_20200401-20200430.nc produced errors:
+raw # days: 30 - resampled # days: 30
+Dates in raw not in resampled: {'2020-04-30'}
+Dates in resampled not in raw: {'2020-03-30'}
+File: tasmax_hadukgrid_uk_1km_day_20200501-20200531.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2020-05-31'}
+Dates in resampled not in raw: {'2020-04-30'}
+File: tasmax_hadukgrid_uk_1km_day_20200601-20200630.nc produced errors:
+raw # days: 30 - resampled # days: 30
+Dates in raw not in resampled: {'2020-06-30'}
+Dates in resampled not in raw: {'2020-05-30'}
+File: tasmax_hadukgrid_uk_1km_day_20200701-20200731.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2020-07-31'}
+Dates in resampled not in raw: {'2020-06-30'}
+File: tasmax_hadukgrid_uk_1km_day_20200801-20200831.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2020-08-31'}
+Dates in resampled not in raw: {'2020-07-30'}
+File: tasmax_hadukgrid_uk_1km_day_20201001-20201031.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2020-10-31'}
+Dates in resampled not in raw: {'2020-09-30'}
+File: tasmax_hadukgrid_uk_1km_day_20201201-20201231.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2020-12-31'}
+Dates in resampled not in raw: {'2020-11-30'}
+File: tasmax_hadukgrid_uk_1km_day_20210101-20210131.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2021-01-31'}
+Dates in resampled not in raw: {'2021-02-01'}
+File: tasmax_hadukgrid_uk_1km_day_20210201-20210228.nc produced errors:
+raw # days: 28 - resampled # days: 27
+Dates in raw not in resampled: {'2021-02-01'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_20210301-20210331.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2021-03-31', '2021-03-30'}
+Dates in resampled not in raw: {'2021-02-30', '2021-02-29'}
+File: tasmax_hadukgrid_uk_1km_day_20210401-20210430.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'2021-04-29', '2021-04-30'}
+Dates in resampled not in raw: {'2021-03-30'}
+File: tasmax_hadukgrid_uk_1km_day_20210501-20210531.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2021-05-30', '2021-05-31'}
+Dates in resampled not in raw: {'2021-04-29', '2021-04-30'}
+File: tasmax_hadukgrid_uk_1km_day_20210601-20210630.nc produced errors:
+raw # days: 30 - resampled # days: 30
+Dates in raw not in resampled: {'2021-06-30'}
+Dates in resampled not in raw: {'2021-05-30'}
+File: tasmax_hadukgrid_uk_1km_day_20210701-20210731.nc produced errors:
+raw # days: 31 - resampled # days: 30
+Dates in raw not in resampled: {'2021-07-31', '2021-07-30'}
+Dates in resampled not in raw: {'2021-06-30'}
+File: tasmax_hadukgrid_uk_1km_day_20210801-20210831.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2021-08-31'}
+Dates in resampled not in raw: {'2021-07-30'}
+File: tasmax_hadukgrid_uk_1km_day_20210901-20210930.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'2021-09-30'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_20211001-20211031.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2021-10-31'}
+Dates in resampled not in raw: {'2021-09-30'}
+File: tasmax_hadukgrid_uk_1km_day_20211101-20211130.nc produced errors:
+raw # days: 30 - resampled # days: 29
+Dates in raw not in resampled: {'2021-11-30'}
+Dates in resampled not in raw: set()
+File: tasmax_hadukgrid_uk_1km_day_20211201-20211231.nc produced errors:
+raw # days: 31 - resampled # days: 31
+Dates in raw not in resampled: {'2021-12-31'}
+Dates in resampled not in raw: {'2021-11-30'}

--- a/python/resampling/check_calendar_log.txt
+++ b/python/resampling/check_calendar_log.txt
@@ -50,19 +50,19 @@ Dates in raw not in resampled: {'1981-03-31', '1981-03-30'}
 Dates in resampled not in raw: {'1981-02-29', '1981-02-30'}
 File: tasmax_hadukgrid_uk_1km_day_19810401-19810430.nc produced errors:
 raw # days: 30 - resampled # days: 29
-Dates in raw not in resampled: {'1981-04-30', '1981-04-29'}
+Dates in raw not in resampled: {'1981-04-29', '1981-04-30'}
 Dates in resampled not in raw: {'1981-03-30'}
 File: tasmax_hadukgrid_uk_1km_day_19810501-19810531.nc produced errors:
 raw # days: 31 - resampled # days: 31
-Dates in raw not in resampled: {'1981-05-31', '1981-05-30'}
-Dates in resampled not in raw: {'1981-04-30', '1981-04-29'}
+Dates in raw not in resampled: {'1981-05-30', '1981-05-31'}
+Dates in resampled not in raw: {'1981-04-29', '1981-04-30'}
 File: tasmax_hadukgrid_uk_1km_day_19810601-19810630.nc produced errors:
 raw # days: 30 - resampled # days: 30
 Dates in raw not in resampled: {'1981-06-30'}
 Dates in resampled not in raw: {'1981-05-30'}
 File: tasmax_hadukgrid_uk_1km_day_19810701-19810731.nc produced errors:
 raw # days: 31 - resampled # days: 30
-Dates in raw not in resampled: {'1981-07-31', '1981-07-30'}
+Dates in raw not in resampled: {'1981-07-30', '1981-07-31'}
 Dates in resampled not in raw: {'1981-06-30'}
 File: tasmax_hadukgrid_uk_1km_day_19810801-19810831.nc produced errors:
 raw # days: 31 - resampled # days: 31
@@ -95,14 +95,14 @@ Dates in resampled not in raw: set()
 File: tasmax_hadukgrid_uk_1km_day_19820301-19820331.nc produced errors:
 raw # days: 31 - resampled # days: 31
 Dates in raw not in resampled: {'1982-03-30', '1982-03-31'}
-Dates in resampled not in raw: {'1982-02-30', '1982-02-29'}
+Dates in resampled not in raw: {'1982-02-29', '1982-02-30'}
 File: tasmax_hadukgrid_uk_1km_day_19820401-19820430.nc produced errors:
 raw # days: 30 - resampled # days: 29
 Dates in raw not in resampled: {'1982-04-29', '1982-04-30'}
 Dates in resampled not in raw: {'1982-03-30'}
 File: tasmax_hadukgrid_uk_1km_day_19820501-19820531.nc produced errors:
 raw # days: 31 - resampled # days: 31
-Dates in raw not in resampled: {'1982-05-31', '1982-05-30'}
+Dates in raw not in resampled: {'1982-05-30', '1982-05-31'}
 Dates in resampled not in raw: {'1982-04-29', '1982-04-30'}
 File: tasmax_hadukgrid_uk_1km_day_19820601-19820630.nc produced errors:
 raw # days: 30 - resampled # days: 30
@@ -110,7 +110,7 @@ Dates in raw not in resampled: {'1982-06-30'}
 Dates in resampled not in raw: {'1982-05-30'}
 File: tasmax_hadukgrid_uk_1km_day_19820701-19820731.nc produced errors:
 raw # days: 31 - resampled # days: 30
-Dates in raw not in resampled: {'1982-07-30', '1982-07-31'}
+Dates in raw not in resampled: {'1982-07-31', '1982-07-30'}
 Dates in resampled not in raw: {'1982-06-30'}
 File: tasmax_hadukgrid_uk_1km_day_19820801-19820831.nc produced errors:
 raw # days: 31 - resampled # days: 31
@@ -143,15 +143,15 @@ Dates in resampled not in raw: set()
 File: tasmax_hadukgrid_uk_1km_day_19830301-19830331.nc produced errors:
 raw # days: 31 - resampled # days: 31
 Dates in raw not in resampled: {'1983-03-30', '1983-03-31'}
-Dates in resampled not in raw: {'1983-02-29', '1983-02-30'}
+Dates in resampled not in raw: {'1983-02-30', '1983-02-29'}
 File: tasmax_hadukgrid_uk_1km_day_19830401-19830430.nc produced errors:
 raw # days: 30 - resampled # days: 29
-Dates in raw not in resampled: {'1983-04-29', '1983-04-30'}
+Dates in raw not in resampled: {'1983-04-30', '1983-04-29'}
 Dates in resampled not in raw: {'1983-03-30'}
 File: tasmax_hadukgrid_uk_1km_day_19830501-19830531.nc produced errors:
 raw # days: 31 - resampled # days: 31
-Dates in raw not in resampled: {'1983-05-30', '1983-05-31'}
-Dates in resampled not in raw: {'1983-04-29', '1983-04-30'}
+Dates in raw not in resampled: {'1983-05-31', '1983-05-30'}
+Dates in resampled not in raw: {'1983-04-30', '1983-04-29'}
 File: tasmax_hadukgrid_uk_1km_day_19830601-19830630.nc produced errors:
 raw # days: 30 - resampled # days: 30
 Dates in raw not in resampled: {'1983-06-30'}
@@ -226,23 +226,23 @@ Dates in raw not in resampled: {'1985-02-01'}
 Dates in resampled not in raw: set()
 File: tasmax_hadukgrid_uk_1km_day_19850301-19850331.nc produced errors:
 raw # days: 31 - resampled # days: 31
-Dates in raw not in resampled: {'1985-03-30', '1985-03-31'}
+Dates in raw not in resampled: {'1985-03-31', '1985-03-30'}
 Dates in resampled not in raw: {'1985-02-30', '1985-02-29'}
 File: tasmax_hadukgrid_uk_1km_day_19850401-19850430.nc produced errors:
 raw # days: 30 - resampled # days: 29
-Dates in raw not in resampled: {'1985-04-30', '1985-04-29'}
+Dates in raw not in resampled: {'1985-04-29', '1985-04-30'}
 Dates in resampled not in raw: {'1985-03-30'}
 File: tasmax_hadukgrid_uk_1km_day_19850501-19850531.nc produced errors:
 raw # days: 31 - resampled # days: 31
-Dates in raw not in resampled: {'1985-05-30', '1985-05-31'}
-Dates in resampled not in raw: {'1985-04-30', '1985-04-29'}
+Dates in raw not in resampled: {'1985-05-31', '1985-05-30'}
+Dates in resampled not in raw: {'1985-04-29', '1985-04-30'}
 File: tasmax_hadukgrid_uk_1km_day_19850601-19850630.nc produced errors:
 raw # days: 30 - resampled # days: 30
 Dates in raw not in resampled: {'1985-06-30'}
 Dates in resampled not in raw: {'1985-05-30'}
 File: tasmax_hadukgrid_uk_1km_day_19850701-19850731.nc produced errors:
 raw # days: 31 - resampled # days: 30
-Dates in raw not in resampled: {'1985-07-30', '1985-07-31'}
+Dates in raw not in resampled: {'1985-07-31', '1985-07-30'}
 Dates in resampled not in raw: {'1985-06-30'}
 File: tasmax_hadukgrid_uk_1km_day_19850801-19850831.nc produced errors:
 raw # days: 31 - resampled # days: 31
@@ -274,16 +274,16 @@ Dates in raw not in resampled: {'1986-02-01'}
 Dates in resampled not in raw: set()
 File: tasmax_hadukgrid_uk_1km_day_19860301-19860331.nc produced errors:
 raw # days: 31 - resampled # days: 31
-Dates in raw not in resampled: {'1986-03-30', '1986-03-31'}
-Dates in resampled not in raw: {'1986-02-30', '1986-02-29'}
+Dates in raw not in resampled: {'1986-03-31', '1986-03-30'}
+Dates in resampled not in raw: {'1986-02-29', '1986-02-30'}
 File: tasmax_hadukgrid_uk_1km_day_19860401-19860430.nc produced errors:
 raw # days: 30 - resampled # days: 29
-Dates in raw not in resampled: {'1986-04-29', '1986-04-30'}
+Dates in raw not in resampled: {'1986-04-30', '1986-04-29'}
 Dates in resampled not in raw: {'1986-03-30'}
 File: tasmax_hadukgrid_uk_1km_day_19860501-19860531.nc produced errors:
 raw # days: 31 - resampled # days: 31
-Dates in raw not in resampled: {'1986-05-30', '1986-05-31'}
-Dates in resampled not in raw: {'1986-04-29', '1986-04-30'}
+Dates in raw not in resampled: {'1986-05-31', '1986-05-30'}
+Dates in resampled not in raw: {'1986-04-30', '1986-04-29'}
 File: tasmax_hadukgrid_uk_1km_day_19860601-19860630.nc produced errors:
 raw # days: 30 - resampled # days: 30
 Dates in raw not in resampled: {'1986-06-30'}
@@ -322,8 +322,8 @@ Dates in raw not in resampled: {'1987-02-01'}
 Dates in resampled not in raw: set()
 File: tasmax_hadukgrid_uk_1km_day_19870301-19870331.nc produced errors:
 raw # days: 31 - resampled # days: 31
-Dates in raw not in resampled: {'1987-03-31', '1987-03-30'}
-Dates in resampled not in raw: {'1987-02-29', '1987-02-30'}
+Dates in raw not in resampled: {'1987-03-30', '1987-03-31'}
+Dates in resampled not in raw: {'1987-02-30', '1987-02-29'}
 File: tasmax_hadukgrid_uk_1km_day_19870401-19870430.nc produced errors:
 raw # days: 30 - resampled # days: 29
 Dates in raw not in resampled: {'1987-04-29', '1987-04-30'}
@@ -338,7 +338,7 @@ Dates in raw not in resampled: {'1987-06-30'}
 Dates in resampled not in raw: {'1987-05-30'}
 File: tasmax_hadukgrid_uk_1km_day_19870701-19870731.nc produced errors:
 raw # days: 31 - resampled # days: 30
-Dates in raw not in resampled: {'1987-07-30', '1987-07-31'}
+Dates in raw not in resampled: {'1987-07-31', '1987-07-30'}
 Dates in resampled not in raw: {'1987-06-30'}
 File: tasmax_hadukgrid_uk_1km_day_19870801-19870831.nc produced errors:
 raw # days: 31 - resampled # days: 31
@@ -410,12 +410,12 @@ Dates in raw not in resampled: {'1989-03-30', '1989-03-31'}
 Dates in resampled not in raw: {'1989-02-29', '1989-02-30'}
 File: tasmax_hadukgrid_uk_1km_day_19890401-19890430.nc produced errors:
 raw # days: 30 - resampled # days: 29
-Dates in raw not in resampled: {'1989-04-29', '1989-04-30'}
+Dates in raw not in resampled: {'1989-04-30', '1989-04-29'}
 Dates in resampled not in raw: {'1989-03-30'}
 File: tasmax_hadukgrid_uk_1km_day_19890501-19890531.nc produced errors:
 raw # days: 31 - resampled # days: 31
-Dates in raw not in resampled: {'1989-05-31', '1989-05-30'}
-Dates in resampled not in raw: {'1989-04-29', '1989-04-30'}
+Dates in raw not in resampled: {'1989-05-30', '1989-05-31'}
+Dates in resampled not in raw: {'1989-04-30', '1989-04-29'}
 File: tasmax_hadukgrid_uk_1km_day_19890601-19890630.nc produced errors:
 raw # days: 30 - resampled # days: 30
 Dates in raw not in resampled: {'1989-06-30'}
@@ -455,22 +455,22 @@ Dates in resampled not in raw: set()
 File: tasmax_hadukgrid_uk_1km_day_19900301-19900331.nc produced errors:
 raw # days: 31 - resampled # days: 31
 Dates in raw not in resampled: {'1990-03-30', '1990-03-31'}
-Dates in resampled not in raw: {'1990-02-29', '1990-02-30'}
+Dates in resampled not in raw: {'1990-02-30', '1990-02-29'}
 File: tasmax_hadukgrid_uk_1km_day_19900401-19900430.nc produced errors:
 raw # days: 30 - resampled # days: 29
-Dates in raw not in resampled: {'1990-04-30', '1990-04-29'}
+Dates in raw not in resampled: {'1990-04-29', '1990-04-30'}
 Dates in resampled not in raw: {'1990-03-30'}
 File: tasmax_hadukgrid_uk_1km_day_19900501-19900531.nc produced errors:
 raw # days: 31 - resampled # days: 31
 Dates in raw not in resampled: {'1990-05-31', '1990-05-30'}
-Dates in resampled not in raw: {'1990-04-30', '1990-04-29'}
+Dates in resampled not in raw: {'1990-04-29', '1990-04-30'}
 File: tasmax_hadukgrid_uk_1km_day_19900601-19900630.nc produced errors:
 raw # days: 30 - resampled # days: 30
 Dates in raw not in resampled: {'1990-06-30'}
 Dates in resampled not in raw: {'1990-05-30'}
 File: tasmax_hadukgrid_uk_1km_day_19900701-19900731.nc produced errors:
 raw # days: 31 - resampled # days: 30
-Dates in raw not in resampled: {'1990-07-31', '1990-07-30'}
+Dates in raw not in resampled: {'1990-07-30', '1990-07-31'}
 Dates in resampled not in raw: {'1990-06-30'}
 File: tasmax_hadukgrid_uk_1km_day_19900801-19900831.nc produced errors:
 raw # days: 31 - resampled # days: 31
@@ -502,16 +502,16 @@ Dates in raw not in resampled: {'1991-02-01'}
 Dates in resampled not in raw: set()
 File: tasmax_hadukgrid_uk_1km_day_19910301-19910331.nc produced errors:
 raw # days: 31 - resampled # days: 31
-Dates in raw not in resampled: {'1991-03-30', '1991-03-31'}
+Dates in raw not in resampled: {'1991-03-31', '1991-03-30'}
 Dates in resampled not in raw: {'1991-02-29', '1991-02-30'}
 File: tasmax_hadukgrid_uk_1km_day_19910401-19910430.nc produced errors:
 raw # days: 30 - resampled # days: 29
-Dates in raw not in resampled: {'1991-04-30', '1991-04-29'}
+Dates in raw not in resampled: {'1991-04-29', '1991-04-30'}
 Dates in resampled not in raw: {'1991-03-30'}
 File: tasmax_hadukgrid_uk_1km_day_19910501-19910531.nc produced errors:
 raw # days: 31 - resampled # days: 31
-Dates in raw not in resampled: {'1991-05-30', '1991-05-31'}
-Dates in resampled not in raw: {'1991-04-30', '1991-04-29'}
+Dates in raw not in resampled: {'1991-05-31', '1991-05-30'}
+Dates in resampled not in raw: {'1991-04-29', '1991-04-30'}
 File: tasmax_hadukgrid_uk_1km_day_19910601-19910630.nc produced errors:
 raw # days: 30 - resampled # days: 30
 Dates in raw not in resampled: {'1991-06-30'}
@@ -586,16 +586,16 @@ Dates in raw not in resampled: {'1993-02-01'}
 Dates in resampled not in raw: set()
 File: tasmax_hadukgrid_uk_1km_day_19930301-19930331.nc produced errors:
 raw # days: 31 - resampled # days: 31
-Dates in raw not in resampled: {'1993-03-31', '1993-03-30'}
-Dates in resampled not in raw: {'1993-02-30', '1993-02-29'}
+Dates in raw not in resampled: {'1993-03-30', '1993-03-31'}
+Dates in resampled not in raw: {'1993-02-29', '1993-02-30'}
 File: tasmax_hadukgrid_uk_1km_day_19930401-19930430.nc produced errors:
 raw # days: 30 - resampled # days: 29
-Dates in raw not in resampled: {'1993-04-30', '1993-04-29'}
+Dates in raw not in resampled: {'1993-04-29', '1993-04-30'}
 Dates in resampled not in raw: {'1993-03-30'}
 File: tasmax_hadukgrid_uk_1km_day_19930501-19930531.nc produced errors:
 raw # days: 31 - resampled # days: 31
 Dates in raw not in resampled: {'1993-05-31', '1993-05-30'}
-Dates in resampled not in raw: {'1993-04-30', '1993-04-29'}
+Dates in resampled not in raw: {'1993-04-29', '1993-04-30'}
 File: tasmax_hadukgrid_uk_1km_day_19930601-19930630.nc produced errors:
 raw # days: 30 - resampled # days: 30
 Dates in raw not in resampled: {'1993-06-30'}
@@ -634,8 +634,8 @@ Dates in raw not in resampled: {'1994-02-01'}
 Dates in resampled not in raw: set()
 File: tasmax_hadukgrid_uk_1km_day_19940301-19940331.nc produced errors:
 raw # days: 31 - resampled # days: 31
-Dates in raw not in resampled: {'1994-03-31', '1994-03-30'}
-Dates in resampled not in raw: {'1994-02-30', '1994-02-29'}
+Dates in raw not in resampled: {'1994-03-30', '1994-03-31'}
+Dates in resampled not in raw: {'1994-02-29', '1994-02-30'}
 File: tasmax_hadukgrid_uk_1km_day_19940401-19940430.nc produced errors:
 raw # days: 30 - resampled # days: 29
 Dates in raw not in resampled: {'1994-04-30', '1994-04-29'}
@@ -683,15 +683,15 @@ Dates in resampled not in raw: set()
 File: tasmax_hadukgrid_uk_1km_day_19950301-19950331.nc produced errors:
 raw # days: 31 - resampled # days: 31
 Dates in raw not in resampled: {'1995-03-31', '1995-03-30'}
-Dates in resampled not in raw: {'1995-02-29', '1995-02-30'}
+Dates in resampled not in raw: {'1995-02-30', '1995-02-29'}
 File: tasmax_hadukgrid_uk_1km_day_19950401-19950430.nc produced errors:
 raw # days: 30 - resampled # days: 29
-Dates in raw not in resampled: {'1995-04-30', '1995-04-29'}
+Dates in raw not in resampled: {'1995-04-29', '1995-04-30'}
 Dates in resampled not in raw: {'1995-03-30'}
 File: tasmax_hadukgrid_uk_1km_day_19950501-19950531.nc produced errors:
 raw # days: 31 - resampled # days: 31
 Dates in raw not in resampled: {'1995-05-30', '1995-05-31'}
-Dates in resampled not in raw: {'1995-04-30', '1995-04-29'}
+Dates in resampled not in raw: {'1995-04-29', '1995-04-30'}
 File: tasmax_hadukgrid_uk_1km_day_19950601-19950630.nc produced errors:
 raw # days: 30 - resampled # days: 30
 Dates in raw not in resampled: {'1995-06-30'}
@@ -770,12 +770,12 @@ Dates in raw not in resampled: {'1997-03-30', '1997-03-31'}
 Dates in resampled not in raw: {'1997-02-29', '1997-02-30'}
 File: tasmax_hadukgrid_uk_1km_day_19970401-19970430.nc produced errors:
 raw # days: 30 - resampled # days: 29
-Dates in raw not in resampled: {'1997-04-29', '1997-04-30'}
+Dates in raw not in resampled: {'1997-04-30', '1997-04-29'}
 Dates in resampled not in raw: {'1997-03-30'}
 File: tasmax_hadukgrid_uk_1km_day_19970501-19970531.nc produced errors:
 raw # days: 31 - resampled # days: 31
-Dates in raw not in resampled: {'1997-05-31', '1997-05-30'}
-Dates in resampled not in raw: {'1997-04-29', '1997-04-30'}
+Dates in raw not in resampled: {'1997-05-30', '1997-05-31'}
+Dates in resampled not in raw: {'1997-04-30', '1997-04-29'}
 File: tasmax_hadukgrid_uk_1km_day_19970601-19970630.nc produced errors:
 raw # days: 30 - resampled # days: 30
 Dates in raw not in resampled: {'1997-06-30'}
@@ -818,19 +818,19 @@ Dates in raw not in resampled: {'1998-03-31', '1998-03-30'}
 Dates in resampled not in raw: {'1998-02-30', '1998-02-29'}
 File: tasmax_hadukgrid_uk_1km_day_19980401-19980430.nc produced errors:
 raw # days: 30 - resampled # days: 29
-Dates in raw not in resampled: {'1998-04-30', '1998-04-29'}
+Dates in raw not in resampled: {'1998-04-29', '1998-04-30'}
 Dates in resampled not in raw: {'1998-03-30'}
 File: tasmax_hadukgrid_uk_1km_day_19980501-19980531.nc produced errors:
 raw # days: 31 - resampled # days: 31
 Dates in raw not in resampled: {'1998-05-30', '1998-05-31'}
-Dates in resampled not in raw: {'1998-04-30', '1998-04-29'}
+Dates in resampled not in raw: {'1998-04-29', '1998-04-30'}
 File: tasmax_hadukgrid_uk_1km_day_19980601-19980630.nc produced errors:
 raw # days: 30 - resampled # days: 30
 Dates in raw not in resampled: {'1998-06-30'}
 Dates in resampled not in raw: {'1998-05-30'}
 File: tasmax_hadukgrid_uk_1km_day_19980701-19980731.nc produced errors:
 raw # days: 31 - resampled # days: 30
-Dates in raw not in resampled: {'1998-07-30', '1998-07-31'}
+Dates in raw not in resampled: {'1998-07-31', '1998-07-30'}
 Dates in resampled not in raw: {'1998-06-30'}
 File: tasmax_hadukgrid_uk_1km_day_19980801-19980831.nc produced errors:
 raw # days: 31 - resampled # days: 31
@@ -862,23 +862,23 @@ Dates in raw not in resampled: {'1999-02-01'}
 Dates in resampled not in raw: set()
 File: tasmax_hadukgrid_uk_1km_day_19990301-19990331.nc produced errors:
 raw # days: 31 - resampled # days: 31
-Dates in raw not in resampled: {'1999-03-30', '1999-03-31'}
-Dates in resampled not in raw: {'1999-02-30', '1999-02-29'}
+Dates in raw not in resampled: {'1999-03-31', '1999-03-30'}
+Dates in resampled not in raw: {'1999-02-29', '1999-02-30'}
 File: tasmax_hadukgrid_uk_1km_day_19990401-19990430.nc produced errors:
 raw # days: 30 - resampled # days: 29
-Dates in raw not in resampled: {'1999-04-30', '1999-04-29'}
+Dates in raw not in resampled: {'1999-04-29', '1999-04-30'}
 Dates in resampled not in raw: {'1999-03-30'}
 File: tasmax_hadukgrid_uk_1km_day_19990501-19990531.nc produced errors:
 raw # days: 31 - resampled # days: 31
-Dates in raw not in resampled: {'1999-05-31', '1999-05-30'}
-Dates in resampled not in raw: {'1999-04-30', '1999-04-29'}
+Dates in raw not in resampled: {'1999-05-30', '1999-05-31'}
+Dates in resampled not in raw: {'1999-04-29', '1999-04-30'}
 File: tasmax_hadukgrid_uk_1km_day_19990601-19990630.nc produced errors:
 raw # days: 30 - resampled # days: 30
 Dates in raw not in resampled: {'1999-06-30'}
 Dates in resampled not in raw: {'1999-05-30'}
 File: tasmax_hadukgrid_uk_1km_day_19990701-19990731.nc produced errors:
 raw # days: 31 - resampled # days: 30
-Dates in raw not in resampled: {'1999-07-30', '1999-07-31'}
+Dates in raw not in resampled: {'1999-07-31', '1999-07-30'}
 Dates in resampled not in raw: {'1999-06-30'}
 File: tasmax_hadukgrid_uk_1km_day_19990801-19990831.nc produced errors:
 raw # days: 31 - resampled # days: 31
@@ -994,8 +994,8 @@ Dates in raw not in resampled: {'2002-02-01'}
 Dates in resampled not in raw: set()
 File: tasmax_hadukgrid_uk_1km_day_20020301-20020331.nc produced errors:
 raw # days: 31 - resampled # days: 31
-Dates in raw not in resampled: {'2002-03-31', '2002-03-30'}
-Dates in resampled not in raw: {'2002-02-30', '2002-02-29'}
+Dates in raw not in resampled: {'2002-03-30', '2002-03-31'}
+Dates in resampled not in raw: {'2002-02-29', '2002-02-30'}
 File: tasmax_hadukgrid_uk_1km_day_20020401-20020430.nc produced errors:
 raw # days: 30 - resampled # days: 29
 Dates in raw not in resampled: {'2002-04-29', '2002-04-30'}
@@ -1010,7 +1010,7 @@ Dates in raw not in resampled: {'2002-06-30'}
 Dates in resampled not in raw: {'2002-05-30'}
 File: tasmax_hadukgrid_uk_1km_day_20020701-20020731.nc produced errors:
 raw # days: 31 - resampled # days: 30
-Dates in raw not in resampled: {'2002-07-30', '2002-07-31'}
+Dates in raw not in resampled: {'2002-07-31', '2002-07-30'}
 Dates in resampled not in raw: {'2002-06-30'}
 File: tasmax_hadukgrid_uk_1km_day_20020801-20020831.nc produced errors:
 raw # days: 31 - resampled # days: 31
@@ -1042,7 +1042,7 @@ Dates in raw not in resampled: {'2003-02-01'}
 Dates in resampled not in raw: set()
 File: tasmax_hadukgrid_uk_1km_day_20030301-20030331.nc produced errors:
 raw # days: 31 - resampled # days: 31
-Dates in raw not in resampled: {'2003-03-30', '2003-03-31'}
+Dates in raw not in resampled: {'2003-03-31', '2003-03-30'}
 Dates in resampled not in raw: {'2003-02-29', '2003-02-30'}
 File: tasmax_hadukgrid_uk_1km_day_20030401-20030430.nc produced errors:
 raw # days: 30 - resampled # days: 29
@@ -1058,7 +1058,7 @@ Dates in raw not in resampled: {'2003-06-30'}
 Dates in resampled not in raw: {'2003-05-30'}
 File: tasmax_hadukgrid_uk_1km_day_20030701-20030731.nc produced errors:
 raw # days: 31 - resampled # days: 30
-Dates in raw not in resampled: {'2003-07-30', '2003-07-31'}
+Dates in raw not in resampled: {'2003-07-31', '2003-07-30'}
 Dates in resampled not in raw: {'2003-06-30'}
 File: tasmax_hadukgrid_uk_1km_day_20030801-20030831.nc produced errors:
 raw # days: 31 - resampled # days: 31
@@ -1126,16 +1126,16 @@ Dates in raw not in resampled: {'2005-02-01'}
 Dates in resampled not in raw: set()
 File: tasmax_hadukgrid_uk_1km_day_20050301-20050331.nc produced errors:
 raw # days: 31 - resampled # days: 31
-Dates in raw not in resampled: {'2005-03-31', '2005-03-30'}
-Dates in resampled not in raw: {'2005-02-29', '2005-02-30'}
+Dates in raw not in resampled: {'2005-03-30', '2005-03-31'}
+Dates in resampled not in raw: {'2005-02-30', '2005-02-29'}
 File: tasmax_hadukgrid_uk_1km_day_20050401-20050430.nc produced errors:
 raw # days: 30 - resampled # days: 29
-Dates in raw not in resampled: {'2005-04-29', '2005-04-30'}
+Dates in raw not in resampled: {'2005-04-30', '2005-04-29'}
 Dates in resampled not in raw: {'2005-03-30'}
 File: tasmax_hadukgrid_uk_1km_day_20050501-20050531.nc produced errors:
 raw # days: 31 - resampled # days: 31
 Dates in raw not in resampled: {'2005-05-31', '2005-05-30'}
-Dates in resampled not in raw: {'2005-04-29', '2005-04-30'}
+Dates in resampled not in raw: {'2005-04-30', '2005-04-29'}
 File: tasmax_hadukgrid_uk_1km_day_20050601-20050630.nc produced errors:
 raw # days: 30 - resampled # days: 30
 Dates in raw not in resampled: {'2005-06-30'}
@@ -1174,23 +1174,23 @@ Dates in raw not in resampled: {'2006-02-01'}
 Dates in resampled not in raw: set()
 File: tasmax_hadukgrid_uk_1km_day_20060301-20060331.nc produced errors:
 raw # days: 31 - resampled # days: 31
-Dates in raw not in resampled: {'2006-03-30', '2006-03-31'}
-Dates in resampled not in raw: {'2006-02-29', '2006-02-30'}
+Dates in raw not in resampled: {'2006-03-31', '2006-03-30'}
+Dates in resampled not in raw: {'2006-02-30', '2006-02-29'}
 File: tasmax_hadukgrid_uk_1km_day_20060401-20060430.nc produced errors:
 raw # days: 30 - resampled # days: 29
-Dates in raw not in resampled: {'2006-04-29', '2006-04-30'}
+Dates in raw not in resampled: {'2006-04-30', '2006-04-29'}
 Dates in resampled not in raw: {'2006-03-30'}
 File: tasmax_hadukgrid_uk_1km_day_20060501-20060531.nc produced errors:
 raw # days: 31 - resampled # days: 31
-Dates in raw not in resampled: {'2006-05-31', '2006-05-30'}
-Dates in resampled not in raw: {'2006-04-29', '2006-04-30'}
+Dates in raw not in resampled: {'2006-05-30', '2006-05-31'}
+Dates in resampled not in raw: {'2006-04-30', '2006-04-29'}
 File: tasmax_hadukgrid_uk_1km_day_20060601-20060630.nc produced errors:
 raw # days: 30 - resampled # days: 30
 Dates in raw not in resampled: {'2006-06-30'}
 Dates in resampled not in raw: {'2006-05-30'}
 File: tasmax_hadukgrid_uk_1km_day_20060701-20060731.nc produced errors:
 raw # days: 31 - resampled # days: 30
-Dates in raw not in resampled: {'2006-07-31', '2006-07-30'}
+Dates in raw not in resampled: {'2006-07-30', '2006-07-31'}
 Dates in resampled not in raw: {'2006-06-30'}
 File: tasmax_hadukgrid_uk_1km_day_20060801-20060831.nc produced errors:
 raw # days: 31 - resampled # days: 31
@@ -1222,23 +1222,23 @@ Dates in raw not in resampled: {'2007-02-01'}
 Dates in resampled not in raw: set()
 File: tasmax_hadukgrid_uk_1km_day_20070301-20070331.nc produced errors:
 raw # days: 31 - resampled # days: 31
-Dates in raw not in resampled: {'2007-03-31', '2007-03-30'}
-Dates in resampled not in raw: {'2007-02-29', '2007-02-30'}
+Dates in raw not in resampled: {'2007-03-30', '2007-03-31'}
+Dates in resampled not in raw: {'2007-02-30', '2007-02-29'}
 File: tasmax_hadukgrid_uk_1km_day_20070401-20070430.nc produced errors:
 raw # days: 30 - resampled # days: 29
-Dates in raw not in resampled: {'2007-04-30', '2007-04-29'}
+Dates in raw not in resampled: {'2007-04-29', '2007-04-30'}
 Dates in resampled not in raw: {'2007-03-30'}
 File: tasmax_hadukgrid_uk_1km_day_20070501-20070531.nc produced errors:
 raw # days: 31 - resampled # days: 31
-Dates in raw not in resampled: {'2007-05-31', '2007-05-30'}
-Dates in resampled not in raw: {'2007-04-30', '2007-04-29'}
+Dates in raw not in resampled: {'2007-05-30', '2007-05-31'}
+Dates in resampled not in raw: {'2007-04-29', '2007-04-30'}
 File: tasmax_hadukgrid_uk_1km_day_20070601-20070630.nc produced errors:
 raw # days: 30 - resampled # days: 30
 Dates in raw not in resampled: {'2007-06-30'}
 Dates in resampled not in raw: {'2007-05-30'}
 File: tasmax_hadukgrid_uk_1km_day_20070701-20070731.nc produced errors:
 raw # days: 31 - resampled # days: 30
-Dates in raw not in resampled: {'2007-07-31', '2007-07-30'}
+Dates in raw not in resampled: {'2007-07-30', '2007-07-31'}
 Dates in resampled not in raw: {'2007-06-30'}
 File: tasmax_hadukgrid_uk_1km_day_20070801-20070831.nc produced errors:
 raw # days: 31 - resampled # days: 31
@@ -1322,7 +1322,7 @@ Dates in raw not in resampled: {'2009-06-30'}
 Dates in resampled not in raw: {'2009-05-30'}
 File: tasmax_hadukgrid_uk_1km_day_20090701-20090731.nc produced errors:
 raw # days: 31 - resampled # days: 30
-Dates in raw not in resampled: {'2009-07-31', '2009-07-30'}
+Dates in raw not in resampled: {'2009-07-30', '2009-07-31'}
 Dates in resampled not in raw: {'2009-06-30'}
 File: tasmax_hadukgrid_uk_1km_day_20090801-20090831.nc produced errors:
 raw # days: 31 - resampled # days: 31
@@ -1354,16 +1354,16 @@ Dates in raw not in resampled: {'2010-02-01'}
 Dates in resampled not in raw: set()
 File: tasmax_hadukgrid_uk_1km_day_20100301-20100331.nc produced errors:
 raw # days: 31 - resampled # days: 31
-Dates in raw not in resampled: {'2010-03-31', '2010-03-30'}
-Dates in resampled not in raw: {'2010-02-29', '2010-02-30'}
+Dates in raw not in resampled: {'2010-03-30', '2010-03-31'}
+Dates in resampled not in raw: {'2010-02-30', '2010-02-29'}
 File: tasmax_hadukgrid_uk_1km_day_20100401-20100430.nc produced errors:
 raw # days: 30 - resampled # days: 29
-Dates in raw not in resampled: {'2010-04-29', '2010-04-30'}
+Dates in raw not in resampled: {'2010-04-30', '2010-04-29'}
 Dates in resampled not in raw: {'2010-03-30'}
 File: tasmax_hadukgrid_uk_1km_day_20100501-20100531.nc produced errors:
 raw # days: 31 - resampled # days: 31
-Dates in raw not in resampled: {'2010-05-30', '2010-05-31'}
-Dates in resampled not in raw: {'2010-04-29', '2010-04-30'}
+Dates in raw not in resampled: {'2010-05-31', '2010-05-30'}
+Dates in resampled not in raw: {'2010-04-30', '2010-04-29'}
 File: tasmax_hadukgrid_uk_1km_day_20100601-20100630.nc produced errors:
 raw # days: 30 - resampled # days: 30
 Dates in raw not in resampled: {'2010-06-30'}
@@ -1402,16 +1402,16 @@ Dates in raw not in resampled: {'2011-02-01'}
 Dates in resampled not in raw: set()
 File: tasmax_hadukgrid_uk_1km_day_20110301-20110331.nc produced errors:
 raw # days: 31 - resampled # days: 31
-Dates in raw not in resampled: {'2011-03-30', '2011-03-31'}
-Dates in resampled not in raw: {'2011-02-29', '2011-02-30'}
+Dates in raw not in resampled: {'2011-03-31', '2011-03-30'}
+Dates in resampled not in raw: {'2011-02-30', '2011-02-29'}
 File: tasmax_hadukgrid_uk_1km_day_20110401-20110430.nc produced errors:
 raw # days: 30 - resampled # days: 29
-Dates in raw not in resampled: {'2011-04-30', '2011-04-29'}
+Dates in raw not in resampled: {'2011-04-29', '2011-04-30'}
 Dates in resampled not in raw: {'2011-03-30'}
 File: tasmax_hadukgrid_uk_1km_day_20110501-20110531.nc produced errors:
 raw # days: 31 - resampled # days: 31
 Dates in raw not in resampled: {'2011-05-30', '2011-05-31'}
-Dates in resampled not in raw: {'2011-04-30', '2011-04-29'}
+Dates in resampled not in raw: {'2011-04-29', '2011-04-30'}
 File: tasmax_hadukgrid_uk_1km_day_20110601-20110630.nc produced errors:
 raw # days: 30 - resampled # days: 30
 Dates in raw not in resampled: {'2011-06-30'}
@@ -1486,23 +1486,23 @@ Dates in raw not in resampled: {'2013-02-01'}
 Dates in resampled not in raw: set()
 File: tasmax_hadukgrid_uk_1km_day_20130301-20130331.nc produced errors:
 raw # days: 31 - resampled # days: 31
-Dates in raw not in resampled: {'2013-03-30', '2013-03-31'}
-Dates in resampled not in raw: {'2013-02-30', '2013-02-29'}
+Dates in raw not in resampled: {'2013-03-31', '2013-03-30'}
+Dates in resampled not in raw: {'2013-02-29', '2013-02-30'}
 File: tasmax_hadukgrid_uk_1km_day_20130401-20130430.nc produced errors:
 raw # days: 30 - resampled # days: 29
-Dates in raw not in resampled: {'2013-04-29', '2013-04-30'}
+Dates in raw not in resampled: {'2013-04-30', '2013-04-29'}
 Dates in resampled not in raw: {'2013-03-30'}
 File: tasmax_hadukgrid_uk_1km_day_20130501-20130531.nc produced errors:
 raw # days: 31 - resampled # days: 31
-Dates in raw not in resampled: {'2013-05-30', '2013-05-31'}
-Dates in resampled not in raw: {'2013-04-29', '2013-04-30'}
+Dates in raw not in resampled: {'2013-05-31', '2013-05-30'}
+Dates in resampled not in raw: {'2013-04-30', '2013-04-29'}
 File: tasmax_hadukgrid_uk_1km_day_20130601-20130630.nc produced errors:
 raw # days: 30 - resampled # days: 30
 Dates in raw not in resampled: {'2013-06-30'}
 Dates in resampled not in raw: {'2013-05-30'}
 File: tasmax_hadukgrid_uk_1km_day_20130701-20130731.nc produced errors:
 raw # days: 31 - resampled # days: 30
-Dates in raw not in resampled: {'2013-07-31', '2013-07-30'}
+Dates in raw not in resampled: {'2013-07-30', '2013-07-31'}
 Dates in resampled not in raw: {'2013-06-30'}
 File: tasmax_hadukgrid_uk_1km_day_20130801-20130831.nc produced errors:
 raw # days: 31 - resampled # days: 31
@@ -1535,22 +1535,22 @@ Dates in resampled not in raw: set()
 File: tasmax_hadukgrid_uk_1km_day_20140301-20140331.nc produced errors:
 raw # days: 31 - resampled # days: 31
 Dates in raw not in resampled: {'2014-03-31', '2014-03-30'}
-Dates in resampled not in raw: {'2014-02-30', '2014-02-29'}
+Dates in resampled not in raw: {'2014-02-29', '2014-02-30'}
 File: tasmax_hadukgrid_uk_1km_day_20140401-20140430.nc produced errors:
 raw # days: 30 - resampled # days: 29
-Dates in raw not in resampled: {'2014-04-29', '2014-04-30'}
+Dates in raw not in resampled: {'2014-04-30', '2014-04-29'}
 Dates in resampled not in raw: {'2014-03-30'}
 File: tasmax_hadukgrid_uk_1km_day_20140501-20140531.nc produced errors:
 raw # days: 31 - resampled # days: 31
 Dates in raw not in resampled: {'2014-05-31', '2014-05-30'}
-Dates in resampled not in raw: {'2014-04-29', '2014-04-30'}
+Dates in resampled not in raw: {'2014-04-30', '2014-04-29'}
 File: tasmax_hadukgrid_uk_1km_day_20140601-20140630.nc produced errors:
 raw # days: 30 - resampled # days: 30
 Dates in raw not in resampled: {'2014-06-30'}
 Dates in resampled not in raw: {'2014-05-30'}
 File: tasmax_hadukgrid_uk_1km_day_20140701-20140731.nc produced errors:
 raw # days: 31 - resampled # days: 30
-Dates in raw not in resampled: {'2014-07-31', '2014-07-30'}
+Dates in raw not in resampled: {'2014-07-30', '2014-07-31'}
 Dates in resampled not in raw: {'2014-06-30'}
 File: tasmax_hadukgrid_uk_1km_day_20140801-20140831.nc produced errors:
 raw # days: 31 - resampled # days: 31
@@ -1590,7 +1590,7 @@ Dates in raw not in resampled: {'2015-04-29', '2015-04-30'}
 Dates in resampled not in raw: {'2015-03-30'}
 File: tasmax_hadukgrid_uk_1km_day_20150501-20150531.nc produced errors:
 raw # days: 31 - resampled # days: 31
-Dates in raw not in resampled: {'2015-05-31', '2015-05-30'}
+Dates in raw not in resampled: {'2015-05-30', '2015-05-31'}
 Dates in resampled not in raw: {'2015-04-29', '2015-04-30'}
 File: tasmax_hadukgrid_uk_1km_day_20150601-20150630.nc produced errors:
 raw # days: 30 - resampled # days: 30
@@ -1666,8 +1666,8 @@ Dates in raw not in resampled: {'2017-02-01'}
 Dates in resampled not in raw: set()
 File: tasmax_hadukgrid_uk_1km_day_20170301-20170331.nc produced errors:
 raw # days: 31 - resampled # days: 31
-Dates in raw not in resampled: {'2017-03-31', '2017-03-30'}
-Dates in resampled not in raw: {'2017-02-29', '2017-02-30'}
+Dates in raw not in resampled: {'2017-03-30', '2017-03-31'}
+Dates in resampled not in raw: {'2017-02-30', '2017-02-29'}
 File: tasmax_hadukgrid_uk_1km_day_20170401-20170430.nc produced errors:
 raw # days: 30 - resampled # days: 29
 Dates in raw not in resampled: {'2017-04-30', '2017-04-29'}
@@ -1715,7 +1715,7 @@ Dates in resampled not in raw: set()
 File: tasmax_hadukgrid_uk_1km_day_20180301-20180331.nc produced errors:
 raw # days: 31 - resampled # days: 31
 Dates in raw not in resampled: {'2018-03-30', '2018-03-31'}
-Dates in resampled not in raw: {'2018-02-30', '2018-02-29'}
+Dates in resampled not in raw: {'2018-02-29', '2018-02-30'}
 File: tasmax_hadukgrid_uk_1km_day_20180401-20180430.nc produced errors:
 raw # days: 30 - resampled # days: 29
 Dates in raw not in resampled: {'2018-04-29', '2018-04-30'}
@@ -1730,7 +1730,7 @@ Dates in raw not in resampled: {'2018-06-30'}
 Dates in resampled not in raw: {'2018-05-30'}
 File: tasmax_hadukgrid_uk_1km_day_20180701-20180731.nc produced errors:
 raw # days: 31 - resampled # days: 30
-Dates in raw not in resampled: {'2018-07-31', '2018-07-30'}
+Dates in raw not in resampled: {'2018-07-30', '2018-07-31'}
 Dates in resampled not in raw: {'2018-06-30'}
 File: tasmax_hadukgrid_uk_1km_day_20180801-20180831.nc produced errors:
 raw # days: 31 - resampled # days: 31
@@ -1763,22 +1763,22 @@ Dates in resampled not in raw: set()
 File: tasmax_hadukgrid_uk_1km_day_20190301-20190331.nc produced errors:
 raw # days: 31 - resampled # days: 31
 Dates in raw not in resampled: {'2019-03-31', '2019-03-30'}
-Dates in resampled not in raw: {'2019-02-29', '2019-02-30'}
+Dates in resampled not in raw: {'2019-02-30', '2019-02-29'}
 File: tasmax_hadukgrid_uk_1km_day_20190401-20190430.nc produced errors:
 raw # days: 30 - resampled # days: 29
-Dates in raw not in resampled: {'2019-04-29', '2019-04-30'}
+Dates in raw not in resampled: {'2019-04-30', '2019-04-29'}
 Dates in resampled not in raw: {'2019-03-30'}
 File: tasmax_hadukgrid_uk_1km_day_20190501-20190531.nc produced errors:
 raw # days: 31 - resampled # days: 31
 Dates in raw not in resampled: {'2019-05-31', '2019-05-30'}
-Dates in resampled not in raw: {'2019-04-29', '2019-04-30'}
+Dates in resampled not in raw: {'2019-04-30', '2019-04-29'}
 File: tasmax_hadukgrid_uk_1km_day_20190601-20190630.nc produced errors:
 raw # days: 30 - resampled # days: 30
 Dates in raw not in resampled: {'2019-06-30'}
 Dates in resampled not in raw: {'2019-05-30'}
 File: tasmax_hadukgrid_uk_1km_day_20190701-20190731.nc produced errors:
 raw # days: 31 - resampled # days: 30
-Dates in raw not in resampled: {'2019-07-30', '2019-07-31'}
+Dates in raw not in resampled: {'2019-07-31', '2019-07-30'}
 Dates in resampled not in raw: {'2019-06-30'}
 File: tasmax_hadukgrid_uk_1km_day_20190801-20190831.nc produced errors:
 raw # days: 31 - resampled # days: 31
@@ -1847,14 +1847,14 @@ Dates in resampled not in raw: set()
 File: tasmax_hadukgrid_uk_1km_day_20210301-20210331.nc produced errors:
 raw # days: 31 - resampled # days: 31
 Dates in raw not in resampled: {'2021-03-31', '2021-03-30'}
-Dates in resampled not in raw: {'2021-02-30', '2021-02-29'}
+Dates in resampled not in raw: {'2021-02-29', '2021-02-30'}
 File: tasmax_hadukgrid_uk_1km_day_20210401-20210430.nc produced errors:
 raw # days: 30 - resampled # days: 29
 Dates in raw not in resampled: {'2021-04-29', '2021-04-30'}
 Dates in resampled not in raw: {'2021-03-30'}
 File: tasmax_hadukgrid_uk_1km_day_20210501-20210531.nc produced errors:
 raw # days: 31 - resampled # days: 31
-Dates in raw not in resampled: {'2021-05-30', '2021-05-31'}
+Dates in raw not in resampled: {'2021-05-31', '2021-05-30'}
 Dates in resampled not in raw: {'2021-04-29', '2021-04-30'}
 File: tasmax_hadukgrid_uk_1km_day_20210601-20210630.nc produced errors:
 raw # days: 30 - resampled # days: 30
@@ -1862,7 +1862,7 @@ Dates in raw not in resampled: {'2021-06-30'}
 Dates in resampled not in raw: {'2021-05-30'}
 File: tasmax_hadukgrid_uk_1km_day_20210701-20210731.nc produced errors:
 raw # days: 31 - resampled # days: 30
-Dates in raw not in resampled: {'2021-07-31', '2021-07-30'}
+Dates in raw not in resampled: {'2021-07-30', '2021-07-31'}
 Dates in resampled not in raw: {'2021-06-30'}
 File: tasmax_hadukgrid_uk_1km_day_20210801-20210831.nc produced errors:
 raw # days: 31 - resampled # days: 31
@@ -1884,3 +1884,60 @@ File: tasmax_hadukgrid_uk_1km_day_20211201-20211231.nc produced errors:
 raw # days: 31 - resampled # days: 31
 Dates in raw not in resampled: {'2021-12-31'}
 Dates in resampled not in raw: {'2021-11-30'}
+______________________________
+missing dates: 0
+date '1980-03-30' appears 2 times.
+date '1980-05-30' appears 2 times.
+date '1980-07-30' appears 2 times.
+date '1980-09-30' appears 2 times.
+date '1980-11-30' appears 2 times.
+date '1984-03-30' appears 2 times.
+date '1984-05-30' appears 2 times.
+date '1984-07-30' appears 2 times.
+date '1984-09-30' appears 2 times.
+date '1984-11-30' appears 2 times.
+date '1988-03-30' appears 2 times.
+date '1988-05-30' appears 2 times.
+date '1988-07-30' appears 2 times.
+date '1988-09-30' appears 2 times.
+date '1988-11-30' appears 2 times.
+date '1992-03-30' appears 2 times.
+date '1992-05-30' appears 2 times.
+date '1992-07-30' appears 2 times.
+date '1992-09-30' appears 2 times.
+date '1992-11-30' appears 2 times.
+date '1996-03-30' appears 2 times.
+date '1996-05-30' appears 2 times.
+date '1996-07-30' appears 2 times.
+date '1996-09-30' appears 2 times.
+date '1996-11-30' appears 2 times.
+date '2000-03-30' appears 2 times.
+date '2000-05-30' appears 2 times.
+date '2000-07-30' appears 2 times.
+date '2000-09-30' appears 2 times.
+date '2000-11-30' appears 2 times.
+date '2004-03-30' appears 2 times.
+date '2004-05-30' appears 2 times.
+date '2004-07-30' appears 2 times.
+date '2004-09-30' appears 2 times.
+date '2004-11-30' appears 2 times.
+date '2008-03-30' appears 2 times.
+date '2008-05-30' appears 2 times.
+date '2008-07-30' appears 2 times.
+date '2008-09-30' appears 2 times.
+date '2008-11-30' appears 2 times.
+date '2012-03-30' appears 2 times.
+date '2012-05-30' appears 2 times.
+date '2012-07-30' appears 2 times.
+date '2012-09-30' appears 2 times.
+date '2012-11-30' appears 2 times.
+date '2016-03-30' appears 2 times.
+date '2016-05-30' appears 2 times.
+date '2016-07-30' appears 2 times.
+date '2016-09-30' appears 2 times.
+date '2016-11-30' appears 2 times.
+date '2020-03-30' appears 2 times.
+date '2020-05-30' appears 2 times.
+date '2020-07-30' appears 2 times.
+date '2020-09-30' appears 2 times.
+date '2020-11-30' appears 2 times.

--- a/python/resampling/resampling_hads.py
+++ b/python/resampling/resampling_hads.py
@@ -6,7 +6,7 @@ It resamples temporally to a 360 day calendar.
 
 import argparse
 import pandas as pd
-import xarray as xr
+import xarray as xr #requires rioxarray extension
 import os
 import glob
 import multiprocessing

--- a/python/resampling/resampling_hads.py
+++ b/python/resampling/resampling_hads.py
@@ -29,7 +29,7 @@ def enforce_date_dropping(raw_data: xr.Dataset, converted_data: xr.Dataset) -> x
     Returns:
         xr.Dataset: The converted data with specific dates dropped.
     """
-    month_day_drop = {(1, 31), (4, 1), (6, 1), (8, 1), (9, 31), (12, 1)}
+    month_day_drop = {(1, 31), (4, 1), (6, 1), (8, 1), (10, 1), (12, 1)}
     time_values = pd.DatetimeIndex(raw_data.coords['time'].values)
     
     # Get the indices of the dates to be dropped
@@ -74,7 +74,9 @@ def resample_hadukgrid(x):
 
         # convert to 360 day calendar.
         data_360 = data.convert_calendar(dim='time', calendar='360_day', align_on='year')
-        data_360 = enforce_date_dropping(data,data_360)
+        # apply correction if leap year
+        if data.time.dt.is_leap_year.any():
+            data_360 = enforce_date_dropping(data,data_360)
 
         # the dataset to be resample must have dimensions named projection_x_coordinate and projection_y_coordinate .
         resampled = data_360[[variable]].interp(projection_x_coordinate=x_grid, projection_y_coordinate=y_grid, method="linear")
@@ -93,7 +95,6 @@ def resample_hadukgrid(x):
 if __name__ == "__main__":
     """
     Script to resample UKHADs data from the command line
-
     """
     # Initialize parser
     parser = argparse.ArgumentParser()


### PR DESCRIPTION
This PR completes issue #32 by removing duplicate dates after resampling.
It adds a function enforce_date_dropping() checking for hard coded dates, known to result in duplicates.

It also adds a script check_calendar which compares the before and after resampling and writes all changes to a log file.