### PR TITLE
Interpl method nearest

### DIFF
--- a/bash/combine-iterative-runs.sh
+++ b/bash/combine-iterative-runs.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 
 # Run this script from the root of the `group_run_*` directory
+# "nearest" interpolation method
+# /datadrive/clim-recal-results/group_run_2024-10-14-16-27
+
 
 # /datadrive/clim-recal-results/group_run_2024-09-26-15-11
 # Manaually add in 1981 data from

--- a/bash/combine-iterative-runs.sh
+++ b/bash/combine-iterative-runs.sh
@@ -2,8 +2,9 @@
 
 # Run this script from the root of the `group_run_*` directory
 
-# The directory for "nearest" interpolation method (eg `data-v1.0-rc.2`) is:
-# `/datadrive/clim-recal-results/group_run_2024-10-14-16-27``
+# For example, the directory for "nearest" interpolation method (eg `data-v1.0-rc.2`) is:
+#   `/datadrive/clim-recal-results/group_run_2024-10-14-16-27``
+# but this directory is temporary before publishing
 
 combined_dir=./combined_output
 

--- a/bash/combine-iterative-runs.sh
+++ b/bash/combine-iterative-runs.sh
@@ -8,8 +8,6 @@
 
 combined_dir=./combined_output
 
-# combined_dir=/mnt/vmfileshare/ClimateData/processed_2024_09_26/combined_output
-
 mkdir -p $combined_dir
 
 # Get all output directories

--- a/bash/combine-iterative-runs.sh
+++ b/bash/combine-iterative-runs.sh
@@ -1,17 +1,9 @@
 #!/bin/bash
 
 # Run this script from the root of the `group_run_*` directory
-# "nearest" interpolation method
-# /datadrive/clim-recal-results/group_run_2024-10-14-16-27
 
-
-# /datadrive/clim-recal-results/group_run_2024-09-26-15-11
-# Manaually add in 1981 data from
-# /datadrive/clim-recal-results/group_run_2024-09-30-16-04/run_24-09-30_16-07
-
-# Manaually add in 1982 data from
-# /datadrive/clim-recal-results/group_run_2024-10-07-12-31/run_24-10-07_12-37
-
+# The directory for "nearest" interpolation method (eg `data-v1.0-rc.2`) is:
+# `/datadrive/clim-recal-results/group_run_2024-10-14-16-27``
 
 combined_dir=./combined_output
 

--- a/bash/run-pipeline-iteratively.sh
+++ b/bash/run-pipeline-iteratively.sh
@@ -75,10 +75,6 @@ for year in $(seq $cpm_start_year $cpm_end_year); do
     --all-variables \
     --all-regions \
     --run 01 \
-    --run 05 \
-    --run 06 \
-    --run 07 \
-    --run 08 \
     --execute
    } 2>&1 | tee $log_path/log_$year.txt
 

--- a/bash/run-pipeline-iteratively.sh
+++ b/bash/run-pipeline-iteratively.sh
@@ -32,7 +32,6 @@ mkdir -p $log_path
 
 cpm_start_year=1980
 cpm_end_year=2079
-# cpm_end_year=1982
 
 # First and last year that we have CPM data for
 for year in $(seq $cpm_start_year $cpm_end_year); do

--- a/bash/run-pipeline-iteratively.sh
+++ b/bash/run-pipeline-iteratively.sh
@@ -30,8 +30,8 @@ mkdir -p $cpm_working_dir
 mkdir -p $log_path
 
 
-cpm_start_year=1982
-cpm_end_year=1982
+cpm_start_year=1980
+cpm_end_year=2079
 # cpm_end_year=1982
 
 # First and last year that we have CPM data for
@@ -75,6 +75,10 @@ for year in $(seq $cpm_start_year $cpm_end_year); do
     --all-variables \
     --all-regions \
     --run 01 \
+    --run 05 \
+    --run 06 \
+    --run 07 \
+    --run 08 \
     --execute
    } 2>&1 | tee $log_path/log_$year.txt
 

--- a/python/clim_recal/utils/data.py
+++ b/python/clim_recal/utils/data.py
@@ -132,7 +132,8 @@ MONTH_DAY_XARRAY_NO_LEAP_YEAR_DROP: DropDayType = {
 }
 """A `set` of month and day tuples dropped for `xarray.day_360` non leap years."""
 
-DEFAULT_INTERPOLATION_METHOD: str = "linear"
+# DEFAULT_INTERPOLATION_METHOD: str = "linear"
+DEFAULT_INTERPOLATION_METHOD: str = "nearest"
 """Default method to infer missing estimates in a time series."""
 
 CFCalendarSTANDARD: Final[str] = "standard"

--- a/python/clim_recal/utils/data.py
+++ b/python/clim_recal/utils/data.py
@@ -132,7 +132,10 @@ MONTH_DAY_XARRAY_NO_LEAP_YEAR_DROP: DropDayType = {
 }
 """A `set` of month and day tuples dropped for `xarray.day_360` non leap years."""
 
+# Default temporal interpolation method (used for `data-v1.0-rc.1`)
 # DEFAULT_INTERPOLATION_METHOD: str = "linear"
+
+# Default temporal interpolation method (used for `data-v1.0-rc.2`)
 DEFAULT_INTERPOLATION_METHOD: str = "nearest"
 """Default method to infer missing estimates in a time series."""
 


### PR DESCRIPTION
This PR changes the temporal interpolation method to "nearest" (rather than "linear", which was previously used).

The commit `ad711e671dfcbd5beb87728c7358295972dfebdb` is the code that was used to create the data for the release `data-v1.0-rc.2`.