### PR TITLE
docs: add content to reproducibility page

### DIFF
--- a/docs/reproducibility.qmd
+++ b/docs/reproducibility.qmd
@@ -1,1 +1,26 @@
-TODO - add details
+# Reproducibility
+
+This page describes how we used the clim-recal package to produce the [pre-processed data](download).
+
+There are two main scripts that we used, described below, to run the pre-processing pipeline.
+
+## bash/run-pipeline-iteratively.sh
+
+This script is used as a wrapper for clime-recal. For performance reasons and to aid debugging, it was helpful run the pipeline iteratively on individual years of data. It is also useful to record the specific options applied to clim-recal. 
+
+* `--all-variables` => "tasmax, tasmin, pr/rainfall"
+* `--all-regions` => "Glasgow, London, Manchester, Scotland"
+* `--run 01`, `--run 05`, `--run 06`, --run 07`, `--run 08` => The data from CPM runs 01, 05, 06 and 07.
+
+An summary of the operation of this script:
+
+* Creates temporary directories to hold one year of CPM and HADs data on a local, fast disk.
+* Loops through each year of data (1980 through to 2080). For each year it:
+    * Copies the relevant CPM and HAD files into the working directory, whilst maintaining the directory structure.
+    * Runs Clim-recal using the options above.
+    * Deletes certain extraneous crop files. (Due to a bug, certain output files are created multiple times. As a workaround we simply deleted the extra files by calling `bash/remove-extra-cropfiles.py` from run-pipeline-iteratively shell script).
+
+
+## bash/combine-iterative-runs.sh
+
+A side effect of running the pipeline iteratively, is that the outputs for each year are placed in their own timestamped directory. This script uses rsync to combine these into a single coherent output directory.


### PR DESCRIPTION
The PR adds a description of how we used `clime-recal` to produce the published data files.